### PR TITLE
ci: add latest version of maven plugins

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -16,6 +16,4 @@ jobs:
           distribution: 'oracle'
           java-version: '17'
       - name: Run spotless check
-        run: |
-          mvn -v
-          mvn spotless:check
+        run: mvn spotless:check

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -16,4 +16,6 @@ jobs:
           distribution: 'oracle'
           java-version: '17'
       - name: Run spotless check
-        run: mvn spotless:check
+        run: |
+          mvn -v
+          mvn spotless:check

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,11 @@
             </pom>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>3.1.1</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
           <artifactId>maven-install-plugin</artifactId>
           <version>3.1.1</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.11.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.11.0</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.1.2</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
I am unsure why maven pulls some old version of plugins where clearly newer versions are available.