### PR TITLE
ci: run CI on multiple operating systems

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v3
       - name: Setup JDK 17


### PR DESCRIPTION
We run on `windows`, `ubuntu`, and `macOS` for starters.