### PR TITLE
fix: include classes of the project itself

### DIFF
--- a/classfile-fingerprint/src/test/java/io/github/algomaster99/it/GenerateMojoIT.java
+++ b/classfile-fingerprint/src/test/java/io/github/algomaster99/it/GenerateMojoIT.java
@@ -3,6 +3,7 @@ package io.github.algomaster99.it;
 import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
 
 import com.soebes.itf.jupiter.extension.MavenGoal;
+import com.soebes.itf.jupiter.extension.MavenGoals;
 import com.soebes.itf.jupiter.extension.MavenJupiterExtension;
 import com.soebes.itf.jupiter.extension.MavenOption;
 import com.soebes.itf.jupiter.extension.MavenTest;
@@ -13,15 +14,25 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 
+@MavenGoals(
+        value = {
+            @MavenGoal("compile"),
+            @MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:generate")
+        })
 @MavenJupiterExtension
 class GenerateMojoIT {
 
+    // @MavenGoals was not inherited by nested classes, so we have to repeat it here
     @Nested
+    @MavenGoals(
+            value = {
+                @MavenGoal("compile"),
+                @MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:generate")
+            })
     class Algorithm {
         private static final int CLASSFILES_LOADED = 5992;
 
         @DisplayName("SHA256 - the default algorithm")
-        @MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:generate")
         @MavenTest
         void sha256(MavenExecutionResult result) {
             assertThat(result).isSuccessful();
@@ -33,7 +44,6 @@ class GenerateMojoIT {
         }
 
         @DisplayName("SHA1")
-        @MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:generate")
         @MavenOption("-Dalgorithm=SHA1")
         @MavenTest
         void sha1(MavenExecutionResult result) {
@@ -46,7 +56,6 @@ class GenerateMojoIT {
         }
 
         @DisplayName("MD5")
-        @MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:generate")
         @MavenOption("-Dalgorithm=MD5")
         @MavenTest
         void md5(MavenExecutionResult result) {
@@ -59,7 +68,6 @@ class GenerateMojoIT {
         }
     }
 
-    @MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:generate")
     @MavenTest
     void guava(MavenExecutionResult result) throws IOException {
         assertThat(result).isSuccessful();
@@ -76,7 +84,6 @@ class GenerateMojoIT {
     }
 
     @DisplayName("Classfile fingerprint with native dependency")
-    @MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:generate")
     @MavenTest
     void native_dependency(MavenExecutionResult result) throws IOException {
         assertThat(result).isSuccessful();
@@ -108,7 +115,6 @@ class GenerateMojoIT {
     }
 
     @DisplayName("Different fingerprint should be generated for sub-modules")
-    @MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:generate")
     @MavenTest
     void multi_module(MavenExecutionResult result) {
         assertThat(result).isSuccessful();

--- a/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/guava/pom.xml
+++ b/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/guava/pom.xml
@@ -7,8 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+<!--        Default with maven 3.9.1-->
+<!--        https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#source -->
+        <maven.compiler.source>7</maven.compiler.source>
+        <maven.compiler.target>7</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/guava/pom.xml
+++ b/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/guava/pom.xml
@@ -6,6 +6,11 @@
     <artifactId>guava</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/guava/src/test/resources/expected-classfile.sha256.jsonl
+++ b/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/guava/src/test/resources/expected-classfile.sha256.jsonl
@@ -1,3 +1,4 @@
+{"groupId":"org.example","artifactId":"guava","version":"1.0-SNAPSHOT","className":"Main","hash":"3daadb44abb68a65f03bd0a49f3d879464aa11d3ff9f71fb3252b0ea281450b1"}
 {"groupId":"com.google.guava","artifactId":"guava","version":"32.1.1-jre","className":"com/google/common/annotations/Beta","hash":"f9af3b23355adb9cd64031476f93eaf7c2f4da7f669289734f371a9d445671e9"}
 {"groupId":"com.google.guava","artifactId":"guava","version":"32.1.1-jre","className":"com/google/common/annotations/GwtCompatible","hash":"fc31bd53be45345a4910c4d4b94cca7b0fa732e8e81329a0f3e975bf9c80e38c"}
 {"groupId":"com.google.guava","artifactId":"guava","version":"32.1.1-jre","className":"com/google/common/annotations/GwtIncompatible","hash":"1d39f39d51809699519bf5aee9b88c7841eaaff3b53e48be2ed692ceb186372b"}


### PR DESCRIPTION
Reference: https://github.com/ASSERT-KTH/terminator/issues/22#issuecomment-1648263338

We ignore maven modules with packaging `pom` as they have no classes. For other packaging types, we throw a warning to the user to ensure that they have compiled the project before.