### PR TITLE
chore: make POM of watchdog-agent compatible with release requirements

### DIFF
--- a/jreleaser.json
+++ b/jreleaser.json
@@ -34,6 +34,18 @@
     }
   },
 
+  "distributions": {
+    "watchdog-agent": {
+      "type": "SINGLE_JAR",
+      "stereotype": "CLI",
+      "artifacts": [
+        {
+          "path": "watchdog-agent/target/{{distributionName}}-{{projectVersion}}.jar"
+        }
+      ]
+    }
+  },
+
   "signing": {
     "active": "ALWAYS",
     "armored": true,

--- a/watchdog-agent/pom.xml
+++ b/watchdog-agent/pom.xml
@@ -113,10 +113,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
       </plugin>
     </plugins>

--- a/watchdog-agent/pom.xml
+++ b/watchdog-agent/pom.xml
@@ -1,18 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>io.github.algomaster99</groupId>
     <artifactId>terminator</artifactId>
     <version>0.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>watchdog-agent</artifactId>
+  <packaging>jar</packaging>
 
   <name>Runtime Agent</name>
+  <description>Exits JVM if unknown class is loaded.</description>
+  <url>${project.parent.url}</url>
 
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
When I run `mvn -Prelease -DskipTests` to stage release, I get the following error:
```bash
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  9.718 s
[INFO] Finished at: 2023-07-25T14:39:18+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.5.0:jar (attach-javadocs) on project watchdog-agent: MavenReportException: Error while generating Javadoc: 
[ERROR] Exit code: 1
[ERROR] /home/aman/personal/who-are-you/watchdog-agent/src/main/java/io/github/algomaster99/Terminator.java:4: error: package java.lang.instrument is not visible
[ERROR] import java.lang.instrument.ClassFileTransformer;
[ERROR]                 ^
[ERROR]   (package java.lang.instrument is declared in module java.instrument, but module com.fasterxml.jackson.databind does not read it)
[ERROR] /home/aman/personal/who-are-you/watchdog-agent/src/main/java/io/github/algomaster99/Terminator.java:5: error: package java.lang.instrument is not visible
[ERROR] import java.lang.instrument.Instrumentation;
[ERROR]                 ^
[ERROR]   (package java.lang.instrument is declared in module java.instrument, but module com.fasterxml.jackson.databind does not read it)
[ERROR] 2 errors
[ERROR] Command line was: /home/aman/.sdkman/candidates/java/17.0.5-oracle/bin/javadoc @options @argfile
[ERROR] 
[ERROR] Refer to the generated Javadoc files in '/home/aman/personal/who-are-you/watchdog-agent/target/apidocs' dir.
[ERROR] 
[ERROR] -> [Help 1]

```

EDIT: ~Fixed in https://github.com/ASSERT-KTH/terminator/pull/29/commits/1d5b6ec3ab8189977f3ed4679dd53f6a64c7ab3e.~

Aparrently,

```
mvn clean
mvn -Prelease -DskipTests
```
is okay


```
mvn install -DskipTests
mvn -Prelease -DskipTests
```
is wrong