### PR TITLE
feat: extract classfiles from submodules

### DIFF
--- a/classfile-fingerprint/src/main/java/io/github/algomaster99/GenerateMojo.java
+++ b/classfile-fingerprint/src/main/java/io/github/algomaster99/GenerateMojo.java
@@ -131,7 +131,10 @@ public class GenerateMojo extends AbstractMojo {
                     .forEach(path -> {
                         String className =
                                 artifactFileOnSystem.toPath().relativize(path).toString();
-                        className = className.substring(0, className.length() - ".class".length());
+                        className = className
+                                .substring(0, className.length() - ".class".length())
+                                // Windows path contain "\\" as delimiters
+                                .replace("\\\\", "/");
                         getLog().debug("Found class: " + className);
                         try (InputStream byteStream = Files.newInputStream(path)) {
                             String hashOfClass = computeHash(byteStream, algorithm);

--- a/classfile-fingerprint/src/main/java/io/github/algomaster99/GenerateMojo.java
+++ b/classfile-fingerprint/src/main/java/io/github/algomaster99/GenerateMojo.java
@@ -134,7 +134,7 @@ public class GenerateMojo extends AbstractMojo {
                         className = className
                                 .substring(0, className.length() - ".class".length())
                                 // Windows path contain "\\" as delimiters
-                                .replace("\\\\", "/");
+                                .replace("\\", "/");
                         getLog().debug("Found class: " + className);
                         try (InputStream byteStream = Files.newInputStream(path)) {
                             String hashOfClass = computeHash(byteStream, algorithm);

--- a/classfile-fingerprint/src/test/java/io/github/algomaster99/it/GenerateMojoIT.java
+++ b/classfile-fingerprint/src/test/java/io/github/algomaster99/it/GenerateMojoIT.java
@@ -134,6 +134,22 @@ class GenerateMojoIT {
         assertThat(bFingerPrint).isRegularFile().isNotEmptyFile();
     }
 
+    @DisplayName("Report classfile's fingerprint of another submodule")
+    @MavenTest
+    void multi_module_with_sources(MavenExecutionResult result) throws IOException {
+        assertThat(result).isSuccessful();
+
+        Path rootModule = result.getMavenProjectResult().getTargetProjectDirectory();
+
+        Path main = Path.of(rootModule.toString(), "main");
+        Path fingerPrint = getFingerprint(main, "classfile.sha256.jsonl");
+
+        Path expectedFingerprint =
+                Path.of(main.toString(), "src", "test", "resources", "expected-classfile.sha256.jsonl");
+
+        assertThat(fingerPrint).isRegularFile().hasContent(Files.readString(expectedFingerprint));
+    }
+
     private static Path getFingerprint(Path projectDirectory, String classfileFingerprintName) {
         return Path.of(projectDirectory.toString(), "target", classfileFingerprintName);
     }

--- a/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/multi_module_with_sources/commons/pom.xml
+++ b/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/multi_module_with_sources/commons/pom.xml
@@ -1,0 +1,10 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.example</groupId>
+        <artifactId>multi-module-with-sources</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>commons</artifactId>
+</project>

--- a/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/multi_module_with_sources/commons/src/main/java/org/example/Pair.java
+++ b/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/multi_module_with_sources/commons/src/main/java/org/example/Pair.java
@@ -1,0 +1,19 @@
+package org.example;
+
+public class Pair {
+    private int first;
+    private int second;
+
+    public Pair(int first, int second) {
+        this.first = first;
+        this.second = second;
+    }
+
+    public int getFirst() {
+        return first;
+    }
+
+    public int getSecond() {
+        return second;
+    }
+}

--- a/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/multi_module_with_sources/main/pom.xml
+++ b/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/multi_module_with_sources/main/pom.xml
@@ -1,0 +1,18 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.example</groupId>
+        <artifactId>multi-module-with-sources</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>main</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>commons</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/multi_module_with_sources/main/src/main/java/Main.java
+++ b/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/multi_module_with_sources/main/src/main/java/Main.java
@@ -1,0 +1,9 @@
+import org.example.Pair;
+
+public class Main {
+    public static void main(String[] args) {
+        Pair pair = new Pair(1, 2);
+        System.out.println(pair.getFirst());
+        System.out.println(pair.getSecond());
+    }
+}

--- a/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/multi_module_with_sources/main/src/test/resources/expected-classfile.sha256.jsonl
+++ b/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/multi_module_with_sources/main/src/test/resources/expected-classfile.sha256.jsonl
@@ -1,2 +1,2 @@
 {"groupId":"org.example","artifactId":"main","version":"1.0.0-SNAPSHOT","className":"Main","hash":"9f7b58e9e3bfd086349dd179d11904cc305fcb8939354b54d890dcf4f2de36a4"}
-{"groupId":"org.example","artifactId":"commons","version":"1.0.0-SNAPSHOT","className":"org/example/Pair","hash":"5ae0fe6962ebfd33ba824551502376f432add2a271d3d0957571de087212be5a"}
+{"groupId":"org.example","artifactId":"commons","version":"1.0.0-SNAPSHOT","className":"org/example/Pair","hash":"af956e490abe20cb1f16cad339aa0ac5ec709fc77743a5f1662cef5a8afca9a0"}

--- a/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/multi_module_with_sources/main/src/test/resources/expected-classfile.sha256.jsonl
+++ b/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/multi_module_with_sources/main/src/test/resources/expected-classfile.sha256.jsonl
@@ -1,2 +1,2 @@
-{"groupId":"org.example","artifactId":"main","version":"1.0.0-SNAPSHOT","className":"Main","hash":"499515919710ab26c4d59594251f826f9d5885b5e5f3e692589a79263eca8f72"}
+{"groupId":"org.example","artifactId":"main","version":"1.0.0-SNAPSHOT","className":"Main","hash":"9f7b58e9e3bfd086349dd179d11904cc305fcb8939354b54d890dcf4f2de36a4"}
 {"groupId":"org.example","artifactId":"commons","version":"1.0.0-SNAPSHOT","className":"org/example/Pair","hash":"5ae0fe6962ebfd33ba824551502376f432add2a271d3d0957571de087212be5a"}

--- a/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/multi_module_with_sources/main/src/test/resources/expected-classfile.sha256.jsonl
+++ b/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/multi_module_with_sources/main/src/test/resources/expected-classfile.sha256.jsonl
@@ -1,0 +1,2 @@
+{"groupId":"org.example","artifactId":"main","version":"1.0.0-SNAPSHOT","className":"Main","hash":"499515919710ab26c4d59594251f826f9d5885b5e5f3e692589a79263eca8f72"}
+{"groupId":"org.example","artifactId":"commons","version":"1.0.0-SNAPSHOT","className":"org/example/Pair","hash":"5ae0fe6962ebfd33ba824551502376f432add2a271d3d0957571de087212be5a"}

--- a/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/multi_module_with_sources/pom.xml
+++ b/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/multi_module_with_sources/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>multi-module-with-sources</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>commons</module>
+        <module>main</module>
+    </modules>
+</project>

--- a/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/multi_module_with_sources/pom.xml
+++ b/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/multi_module_with_sources/pom.xml
@@ -7,6 +7,11 @@
     <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
     <modules>
         <module>commons</module>
         <module>main</module>


### PR DESCRIPTION
Analysing `sorald` lead me to a finding that when `classfile-fingerprint` is analysing a submodule, and if another submodule is a dependency, then it is unable to look into its classes.