### PR TITLE
fix: add `org/w3c/dom` to list of internal packages

### DIFF
--- a/watchdog-agent/src/main/java/io/github/algomaster99/Terminator.java
+++ b/watchdog-agent/src/main/java/io/github/algomaster99/Terminator.java
@@ -14,7 +14,7 @@ public class Terminator {
     private static Options options;
 
     private static final List<String> INTERNAL_PACKAGES =
-            List.of("java/", "javax/", "jdk/", "sun/", "com/sun/", "org/xml/sax");
+            List.of("java/", "javax/", "jdk/", "sun/", "com/sun/", "org/xml/sax", "org/w3c/dom/");
 
     public static void premain(String agentArgs, Instrumentation inst) {
         options = new Options(agentArgs);


### PR DESCRIPTION
https://github.com/apache/pdfbox/releases/tag/3.0.0-beta1 made me discover that `org/w3c/dom` is also an internal package because it loaded [`org/w3c/dom/Element`](https://docs.oracle.com/en/java/javase/17/docs/api/java.xml/org/w3c/dom/Element.html) and `terminator` disallowed it.

Command used
```
java -javaagent:/home/aman/personal/who-are-you/watchdog-agent/target/watchdog-agent-0.7.1-SNAPSHOT.jar=fingerprints=/home/aman/experiments/runtime-integrity/pdfbox/app/target/classfile.sha256.jsonl -jar app/target/pdfbox-app-3.0.0-beta1.jar render --input=$(realpath ../2303.11102.pdf)
```