### PR TITLE
fix: relocate classes in `com.fasterxml.jackson`

### DIFF
--- a/watchdog-agent/pom.xml
+++ b/watchdog-agent/pom.xml
@@ -82,6 +82,10 @@
               <pattern>kotlin</pattern>
               <shadedPattern>rtf.kotlin</shadedPattern>
             </relocation>
+            <relocation>
+              <pattern>com.fasterxml.jackson</pattern>
+              <shadedPattern>rtf.com.fasterxml.jackson</shadedPattern>
+            </relocation>
           </relocations>
         </configuration>
         <executions>


### PR DESCRIPTION
I was running the following command:
```
java -javaagent:/home/aman/personal/who-are-you/watchdog-agent/target/watchdog-agent-0.7.1-SNAPSHOT.jar=fingerprints=/home/aman/experiments/runtime-integrity/graphhopper/web/target/classfile.sha256.jsonl \
-D"dw.graphhopper.datareader.file=berlin-latest.osm.pbf" \
-jar web/target/graphhopper-web-7.0-SNAPSHOT.jar server config-example.yml
```
> Refer https://github.com/graphhopper/graphhopper/tree/7.0#installation

The agent threw an exception while deserialising the fingerprint. It happened because it used the `jackson-databind` (version [`2.10.5.1`](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.10.5.1)) package from the graphhopper. Hence, we need to shade it for our own agent so that there are no version clashes.
