### PR TITLE
fix: make the external jar path relative to config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,13 @@ mvn compile io.github.algomaster99:classfile-fingerprint:generate
 > ```json
 > [
 >  {
->   "path": "path/to/jar",
+>   "path": "path/to/jar"
 >  }
 > ]
+> ```
+> 1. Path to `externalJars` **must** be absolute if the maven project is multimodular.
+> 2. The `path` inside the file is relativized to the path of the `externalJars` file itself.
+>     However, if the path is absolute, it is not relativized.
 
 Both methods will output a file `classfile.sha256.jsonl` in the `target` directory.
 

--- a/classfile-fingerprint/src/main/java/io/github/algomaster99/GenerateMojo.java
+++ b/classfile-fingerprint/src/main/java/io/github/algomaster99/GenerateMojo.java
@@ -3,6 +3,7 @@ package io.github.algomaster99;
 import static io.github.algomaster99.terminator.commons.fingerprint.classfile.HashComputer.computeHash;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.algomaster99.terminator.commons.data.ExternalJar;
 import io.github.algomaster99.terminator.commons.fingerprint.ParsingHelper;
@@ -216,8 +217,10 @@ public class GenerateMojo extends AbstractMojo {
         ObjectMapper mapper = new ObjectMapper();
         List<ExternalJar> externalJarList;
         try {
-            externalJarList =
-                    mapper.readerFor(new TypeReference<List<ExternalJar>>() {}).readValue(externalJars);
+            InjectableValues inject = new InjectableValues.Std().addValue("configFile", externalJars.getAbsolutePath());
+            externalJarList = mapper.setInjectableValues(inject)
+                    .readerFor(new TypeReference<List<ExternalJar>>() {})
+                    .readValue(externalJars);
         } catch (IOException e) {
             throw new RuntimeException("Could not open external jar file: " + e);
         }

--- a/classfile-fingerprint/src/main/java/io/github/algomaster99/GenerateMojo.java
+++ b/classfile-fingerprint/src/main/java/io/github/algomaster99/GenerateMojo.java
@@ -144,6 +144,7 @@ public class GenerateMojo extends AbstractMojo {
             }
         } catch (IOException e) {
             getLog().error("Could not open JAR file: " + artifactFileOnSystem);
+            throw new RuntimeException(e);
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }

--- a/classfile-fingerprint/src/test/java/io/github/algomaster99/it/GenerateMojoIT.java
+++ b/classfile-fingerprint/src/test/java/io/github/algomaster99/it/GenerateMojoIT.java
@@ -180,7 +180,7 @@ class GenerateMojoIT {
     }
 
     @MavenTest
-    @MavenOption("-DexternalJars=src/test/resources/externalJars.json")
+    @MavenOption("-DexternalJars=external_source/externalJars.json")
     void url_classloader_local_jar(MavenExecutionResult result) {
         assertThat(result).isSuccessful();
 

--- a/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/url_classloader_local_jar/external_source/externalJars.json
+++ b/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/url_classloader_local_jar/external_source/externalJars.json
@@ -1,0 +1,5 @@
+[
+  {
+    "path": "non-malicious.jar"
+  }
+]

--- a/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/url_classloader_local_jar/src/test/resources/externalJars.json
+++ b/classfile-fingerprint/src/test/resources-its/io/github/algomaster99/it/GenerateMojoIT/url_classloader_local_jar/src/test/resources/externalJars.json
@@ -1,5 +1,0 @@
-[
-  {
-    "path": "external_source/non-malicious.jar"
-  }
-]

--- a/terminator-commons/src/main/java/io/github/algomaster99/terminator/commons/data/ExternalJar.java
+++ b/terminator-commons/src/main/java/io/github/algomaster99/terminator/commons/data/ExternalJar.java
@@ -1,5 +1,35 @@
 package io.github.algomaster99.terminator.commons.data;
 
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.io.File;
+import java.io.IOException;
 
+@JsonDeserialize(using = ExternalJarDeserialize.class)
 public record ExternalJar(File path) {}
+
+class ExternalJarDeserialize extends JsonDeserializer<ExternalJar> {
+
+    @Override
+    public ExternalJar deserialize(JsonParser jp, DeserializationContext ctx) throws IOException, JacksonException {
+        JsonNode node = jp.getCodec().readTree(jp);
+
+        String configFile = String.valueOf(ctx.findInjectableValue("configFile", null, null));
+
+        File relativePath = new File(node.get("path").asText());
+
+        if (!relativePath.isAbsolute()) {
+            relativePath = new File(configFile)
+                    .getParentFile()
+                    .toPath()
+                    .resolve(relativePath.toPath())
+                    .toFile();
+        }
+
+        return new ExternalJar(relativePath.getAbsoluteFile());
+    }
+}

--- a/terminator-commons/src/main/java/io/github/algomaster99/terminator/commons/data/ExternalJar.java
+++ b/terminator-commons/src/main/java/io/github/algomaster99/terminator/commons/data/ExternalJar.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
 @JsonDeserialize(using = ExternalJarDeserialize.class)
 public record ExternalJar(File path) {}
@@ -20,16 +21,13 @@ class ExternalJarDeserialize extends JsonDeserializer<ExternalJar> {
 
         String configFile = String.valueOf(ctx.findInjectableValue("configFile", null, null));
 
-        File relativePath = new File(node.get("path").asText());
+        File absolutePathOfExternalJar = new File(configFile)
+                .getParentFile()
+                .toPath()
+                // It trivially returns the path of external jar if it is absolute
+                .resolve(Path.of(node.get("path").asText()))
+                .toFile();
 
-        if (!relativePath.isAbsolute()) {
-            relativePath = new File(configFile)
-                    .getParentFile()
-                    .toPath()
-                    .resolve(relativePath.toPath())
-                    .toFile();
-        }
-
-        return new ExternalJar(relativePath.getAbsoluteFile());
+        return new ExternalJar(absolutePathOfExternalJar.getAbsoluteFile());
     }
 }


### PR DESCRIPTION
Fix #49 

`externalJars` must be an absolute path when it is a multi-module project. The changes make sure that the path inside the `externalJars.json` file are relative to the the path of the `externalJars.json` itself.