### PR TITLE
feat: acquit classes that are part of the project itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ java -javaagent:<path/to/agent>=fingerprints=<path/to/fingerprints> -jar <path/t
 
 **Optional Parameters**
 
-|   Parameter    |   Type    | Description                                                                             |
-|:--------------:|:---------:|-----------------------------------------------------------------------------------------|
-| `skipShutdown` | `boolean` | If `true`, the JVM will not shutdown if a prohibited class is loaded. Default: `false`. |
+|   Parameter    |   Type    | Description                                                                                      |
+|:--------------:|:---------:|--------------------------------------------------------------------------------------------------|
+| `skipShutdown` | `boolean` | If `true`, the JVM will not shutdown if a prohibited class is loaded. Default: `false`.          |
+|     `sbom`     |  `File`   | Path to an SBOM file. It is used for including the classes of the root project. Default: `null`. |
+
+> `sbom` is a CycloneDX 1.4 JSON file.

--- a/watchdog-agent/src/main/java/io/github/algomaster99/Options.java
+++ b/watchdog-agent/src/main/java/io/github/algomaster99/Options.java
@@ -2,7 +2,11 @@ package io.github.algomaster99;
 
 import static io.github.algomaster99.terminator.commons.fingerprint.ParsingHelper.deserializeFingerprints;
 
+import io.github.algomaster99.terminator.commons.cyclonedx.Bom14Schema;
+import io.github.algomaster99.terminator.commons.cyclonedx.CycloneDX;
 import io.github.algomaster99.terminator.commons.fingerprint.provenance.Provenance;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -11,6 +15,8 @@ public class Options {
     private Map<String, List<Provenance>> fingerprints;
 
     private boolean skipShutdown = false;
+
+    private Bom14Schema sbom = null;
 
     public Options(String agentArgs) {
         String[] args = agentArgs.split(",");
@@ -29,6 +35,14 @@ public class Options {
                 case "skipShutdown":
                     skipShutdown = Boolean.parseBoolean(value);
                     break;
+                case "sbom":
+                    Path sbomPath = Path.of(value);
+                    try {
+                        sbom = CycloneDX.getPOJO(Files.readString(sbomPath));
+                    } catch (IOException e) {
+                        throw new IllegalArgumentException("Failed to read sbom file: " + value);
+                    }
+                    break;
                 default:
                     throw new IllegalArgumentException("Unknown argument: " + key);
             }
@@ -44,5 +58,9 @@ public class Options {
 
     public boolean shouldSkipShutdown() {
         return skipShutdown;
+    }
+
+    public Bom14Schema getSbom() {
+        return sbom;
     }
 }

--- a/watchdog-agent/src/main/java/io/github/algomaster99/Terminator.java
+++ b/watchdog-agent/src/main/java/io/github/algomaster99/Terminator.java
@@ -1,8 +1,14 @@
 package io.github.algomaster99;
 
 import static io.github.algomaster99.terminator.commons.fingerprint.classfile.HashComputer.computeHash;
+import static io.github.algomaster99.terminator.commons.jar.JarScanner.goInsideJarAndUpdateFingerprints;
 
+import io.github.algomaster99.terminator.commons.cyclonedx.Bom14Schema;
+import io.github.algomaster99.terminator.commons.cyclonedx.Component;
 import io.github.algomaster99.terminator.commons.fingerprint.provenance.Provenance;
+import io.github.algomaster99.terminator.commons.jar.JarDownloader;
+import java.io.File;
+import java.io.IOException;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
 import java.security.NoSuchAlgorithmException;
@@ -33,6 +39,30 @@ public class Terminator {
 
     private static byte[] isLoadedClassWhitelisted(String className, byte[] classfileBuffer) {
         Map<String, List<Provenance>> fingerprints = options.getFingerprints();
+        Bom14Schema sbom = options.getSbom();
+        // Block needed to consider the project's own classes
+        // Assumes that package is released on maven central
+        if (sbom != null) {
+            try {
+                Component rootComponent = sbom.getMetadata().getComponent();
+                File jarFile = JarDownloader.getMavenJarFile(
+                        rootComponent.getGroup(), rootComponent.getName(), rootComponent.getVersion());
+                goInsideJarAndUpdateFingerprints(
+                        jarFile,
+                        fingerprints,
+                        // TODO: Make this configurable
+                        "SHA256",
+                        rootComponent.getGroup(),
+                        rootComponent.getName(),
+                        rootComponent.getVersion());
+            } catch (IOException e) {
+                System.err.println("Failed to download jar file: " + e.getMessage());
+                System.exit(1);
+            } catch (InterruptedException e) {
+                System.err.println("Downloading was interrupted: " + e.getMessage());
+                System.exit(1);
+            }
+        }
         if (INTERNAL_PACKAGES.stream().anyMatch(className::startsWith)) {
             return classfileBuffer;
         }

--- a/watchdog-agent/src/main/java/io/github/algomaster99/Terminator.java
+++ b/watchdog-agent/src/main/java/io/github/algomaster99/Terminator.java
@@ -1,14 +1,8 @@
 package io.github.algomaster99;
 
 import static io.github.algomaster99.terminator.commons.fingerprint.classfile.HashComputer.computeHash;
-import static io.github.algomaster99.terminator.commons.jar.JarScanner.goInsideJarAndUpdateFingerprints;
 
-import io.github.algomaster99.terminator.commons.cyclonedx.Bom14Schema;
-import io.github.algomaster99.terminator.commons.cyclonedx.Component;
 import io.github.algomaster99.terminator.commons.fingerprint.provenance.Provenance;
-import io.github.algomaster99.terminator.commons.jar.JarDownloader;
-import java.io.File;
-import java.io.IOException;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
 import java.security.NoSuchAlgorithmException;
@@ -39,30 +33,6 @@ public class Terminator {
 
     private static byte[] isLoadedClassWhitelisted(String className, byte[] classfileBuffer) {
         Map<String, List<Provenance>> fingerprints = options.getFingerprints();
-        Bom14Schema sbom = options.getSbom();
-        // Block needed to consider the project's own classes
-        // Assumes that package is released on maven central
-        if (sbom != null) {
-            try {
-                Component rootComponent = sbom.getMetadata().getComponent();
-                File jarFile = JarDownloader.getMavenJarFile(
-                        rootComponent.getGroup(), rootComponent.getName(), rootComponent.getVersion());
-                goInsideJarAndUpdateFingerprints(
-                        jarFile,
-                        fingerprints,
-                        // TODO: Make this configurable
-                        "SHA256",
-                        rootComponent.getGroup(),
-                        rootComponent.getName(),
-                        rootComponent.getVersion());
-            } catch (IOException e) {
-                System.err.println("Failed to download jar file: " + e.getMessage());
-                System.exit(1);
-            } catch (InterruptedException e) {
-                System.err.println("Downloading was interrupted: " + e.getMessage());
-                System.exit(1);
-            }
-        }
         if (INTERNAL_PACKAGES.stream().anyMatch(className::startsWith)) {
             return classfileBuffer;
         }

--- a/watchdog-agent/src/test/java/AgentTest.java
+++ b/watchdog-agent/src/test/java/AgentTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class AgentTest {
-    @Disabled("Should be worked upon after the input is from an SBOM and not maven project")
+    @Disabled("Should be worked upon after we know what java version is used by the application")
     @Test
     void shouldDisallowLoadingCustomJDKClass() throws MavenInvocationException, IOException, InterruptedException {
         // contract: watchdog-agent should detect if the class masquerading as an internal class


### PR DESCRIPTION
If `sbom` parameter is passed, we get the root component from there and include that in our fingerprints.