### PR TITLE
tests: run spoon with depscan

### DIFF
--- a/watchdog-agent/src/main/java/io/github/algomaster99/Options.java
+++ b/watchdog-agent/src/main/java/io/github/algomaster99/Options.java
@@ -131,6 +131,14 @@ public class Options {
             try {
                 File jarFile = JarDownloader.getMavenJarFile(
                         component.getGroup(), component.getName(), component.getVersion());
+                if (jarFile == null) {
+                    LOGGER.warn(
+                            "Could not find jar for {}:{}:{}",
+                            component.getGroup(),
+                            component.getName(),
+                            component.getVersion());
+                    continue;
+                }
                 goInsideJarAndUpdateFingerprints(
                         jarFile,
                         fingerprints,

--- a/watchdog-agent/src/test/java/AgentTest.java
+++ b/watchdog-agent/src/test/java/AgentTest.java
@@ -103,16 +103,22 @@ public class AgentTest {
         private final Path project = Paths.get("src/test/resources/spoon-10.4.0");
 
         @Test
-        void spoon_10_4_0_correctSbom() throws IOException, InterruptedException {
+        void spoon_10_4_0_cyclonedx_2_7_4_correctSbom() throws IOException, InterruptedException {
             // contract: spoon 10.4.0 CLI should be self-contained in a fat jar and its execution should not load any
             // classes outside SBOM
             assertThat(runSpoonWithSbom(project.resolve("bom.json"))).isEqualTo(0);
         }
 
         @Test
-        void spoon_10_4_0_wrongSbom() throws IOException, InterruptedException {
+        void spoon_10_4_0_cyclonedx_2_7_4_wrongSbom() throws IOException, InterruptedException {
             // contract: spoon should not execute as the incorrect SBOM is passed (spoon-core is changed to 10.3.0)
             assertThat(runSpoonWithSbom(project.resolve("wrong-bom.json"))).isEqualTo(1);
+        }
+
+        @Test
+        void spoon_10_4_0_depscan_4_2_2() throws IOException, InterruptedException {
+            // contract: spoon should execute as the root component is within component list
+            assertThat(runSpoonWithSbom(project.resolve("sbom-universal.json"))).isEqualTo(0);
         }
 
         private int runSpoonWithSbom(Path sbom) throws IOException, InterruptedException {

--- a/watchdog-agent/src/test/resources/spoon-10.4.0/sbom-universal.json
+++ b/watchdog-agent/src/test/resources/spoon-10.4.0/sbom-universal.json
@@ -1,0 +1,14743 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "serialNumber": "urn:uuid:cb75f397-dc38-449c-a810-7a5de9568c44",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2023-08-28T16:34:14.075Z",
+    "tools": [
+      {
+        "vendor": "cyclonedx",
+        "name": "cdxgen",
+        "version": "8.0.5"
+      }
+    ],
+    "authors": [
+      {
+        "name": "Prabhu Subramanian",
+        "email": "prabhu@appthreat.com"
+      }
+    ]
+  },
+  "components": [
+    {
+      "publisher": "Inria",
+      "group": "fr.inria.gforge.spoon",
+      "name": "spoon-core",
+      "version": "10.3.0",
+      "description": "Spoon is a tool for meta-programming, analysis and transformation of Java programs.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "83b2e0a5518da1eecf60553bf509d116"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d94722f53c95e49d8c1628708e3a168dc748e956"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "37a43de039cf9a6701777106e3c5921e7131e5417fa707709abf791d3d8d9174"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "b73e46c8447c1798286cf5a49a8d42de4d2b41b5d2c88328499f9bcb7e9523da1863c933acf3a815a781e44659ca5838ec7d20956c150a34298292ae3ccb0f56"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "f4aab96931ec156c596e9ed2b2a8e4a505de599163e243044e163e58b1243693d170f64dea9397269887631b90b908a8"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "ef1697ae694ab94cd24e3f6f90239dae4651d5d9c2c9be7b0a6c84ed2e6aaf4424ac176d3c4303435b725a2ef6f0f17f"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "a69e5ad7eb976c32ed04b5d569fc2b8054651d4cd03d1153d20c62cfe98e24de"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "055d0fa95975cbe088435d69bf01108ccf361fb19cb36a70e63a7e994c9704e6ac67f9acab6e3eeb2cbf3f20d2a095725cd48039df49cceabc284824c2eeff61"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "CECILL-C",
+            "url": "http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:maven/fr.inria.gforge.spoon/spoon-core@10.3.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/fr.inria.gforge.spoon/spoon-core@10.3.0?type=jar"
+    },
+    {
+      "publisher": "Eclipse Foundation",
+      "group": "org.eclipse.jdt",
+      "name": "org.eclipse.jdt.core",
+      "version": "3.32.0",
+      "description": "Java Development Tools Core",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "09e8846feeabeca1fd29c57b910694fd"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "89e275d38927f3d6881778f6f86c326e845552a3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "cd396e4368b025f8f898ea7b7693fe5b9b1f6981c365c3857420d178132ef945"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "99850f0830abcc3bf6a85d049f1c7075ffb245e40c5a9a78fe06ca74e2d82826d06698cff0ce1a2e14a519c43adf91b7673d83e931e1482305948b2b2d9ecd8b"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "6a6a36dd24b9647168f9f3b76c56c4b4e6490a076a2a3331b791aa1b1a56000944e89b96f412560d9116716884872a00"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "0ee921700adb3ef23f557554f303859b43ad8a42bfd51c32ef3a7ff4e4e90597e34e898a50347674f2a799624c1c30ca"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "c0dab90c4a5f7cdba9717eefd519276e88f0efa35b69598916538e79d56e9174"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "9f7268511b6521cc59216deb6a810a8daaf99c6281645db8aad76a58b105553f00ce9e63caccf0e0735c673bb279865677fb6e9505758225ae02748b8f584eb1"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "EPL-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.eclipse.jdt/org.eclipse.jdt.core@3.32.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.eclipse.jdt/org.eclipse.jdt.core@3.32.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "com.martiansoftware",
+      "name": "jsap",
+      "version": "2.1",
+      "description": "the Java-based Simple Argument Parser",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "37c5996faaca2c37e6b45c74ffe997aa"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d17c260c8f5eb6e7d6bd75449a57edfeb53d2305"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "331746fa62cfbc3368260c5a2e660936ad11be612308c120a044e120361d474e"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "7d5caa60f9f084efe7a59edb8db09ba261acb9e4be0852134e6c8b9794ae79cd3f4e5c342cecb398d22e3b585c328408545fada4d5b00ba799fb58bf928b8feb"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "ba08a5183432d6d57ed21dc24217f274e515c659d728a9ac53a6333f23134c9a33b874514a07aea457dbb5a6df6dc8a9"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "cd6ff71114e49aa56a520ea0c1996494428c6253a4c47d5c161398e88385093213732ae35f8f8a6f355e51d81f25fd70"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "02e2038dbd1d8274f94c11b3ca919b5ad2c4f5de8e6d6d46b073d327e3df2c2d"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "18ce1f05d2956bcc720f1ae1477fb2d2ab08e916360b4143d40d45a594a56ae37585cc18fbae55d7e9b06cf67f060ebe2ec63add0be3bbb7dbc17906a3d79a3f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPL",
+            "url": "http://www.martiansoftware.com/jsap/license.html"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.martiansoftware/jsap@2.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.martiansoftware/jsap@2.1?type=jar"
+    },
+    {
+      "publisher": "QOS.ch",
+      "group": "org.slf4j",
+      "name": "slf4j-api",
+      "version": "1.7.36",
+      "description": "The slf4j API",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "872da51f5de7f3923da4de871d57fd85"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6c62681a2f655b49963a5983b8b0950a6120ae14"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d3ef575e3e4979678dc01bf1dcce51021493b4d11fb7f1be8ad982877c16a1c0"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "f9b033fc019a44f98b16048da7e2b59edd4a6a527ba60e358f65ab88e0afae03a9340f1b3e8a543d49fa542290f499c5594259affa1ff3e6e7bf3b428d4c610b"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "2b14ad035877087157e379d3277dcdcd79e58d6bdb147c47d29e377d75ce53ad42cafbf22f5fb7827c7e946ff4876b9a"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "3bc3110dafb8d5be16a39f3b2671a466463cd99eb39610c0e4719a7bf2d928f2ea213c734887c6926a07c4cca7769e4b"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "ba2608179fcf46e2291a90b9cbb4aa30d718e481f59c350cc21c73b88d826881"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "14c4edcd19702ef607d78826839d8a6d3a39157df54b89a801d3d3cbbe1307131a77671b041c761122730fb1387888c5ec2e46bdd80e1cb07f8f144676441824"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "commons-io",
+      "name": "commons-io",
+      "version": "2.11.0",
+      "description": "The Apache Commons IO library contains utility classes, stream implementations, file filters, file comparators, endian transformation classes, and much more.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "3b4b7ccfaeceeac240b804839ee1a1ca"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a2503f302b11ebde7ebc3df41daebe0e4eea3689"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "961b2f6d87dbacc5d54abf45ab7a6e2495f89b75598962d8c723cea9bc210908"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "5bd78eed456ede30119319c5bed8e3e4c443b6fd7bdb3a7a5686647bd83094d0c3e2832a7575cfb60e4ef25f08106b93476939d3adcfecf5533cc030b3039e10"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "114f1e324d90ad887c177876d410f5787a8e8da6c48d4b2862d365802c0efded3a88cb24046976bf6276cadad3712f0f"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "80288c03ad4d80d69f91d056ffc5570d49a9c76bf54ad2dff0121ecde26a560df76d05156f281f5c6db2a38ff07a873d"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "5adfb5ccaf5f21a549422f426118a9542673926fcd18c68390cf813e791dcf6c"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "7573f47f0babb53cefdc7c2309a0b982d800139064537b0797da442853d081010ad7c3c74a500598a0f800639a5d540eca21963ea652c68613907059bd4278c2"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/commons-io/commons-io@2.11.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/commons-io/commons-io@2.11.0?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "org.apache.maven",
+      "name": "maven-model",
+      "version": "4.0.0-alpha-7",
+      "description": "Model for Maven POM (Project Object Model)",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "b2a5dfa1c82883fd12fc371faae17f8d"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6eee761eb1e899139a0c5d672246914c7dfd3789"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "37cde0eb7edaea329643ba5a6e95808cdf6678e17327042bfb6679b8f68ab72f"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "b5a27fe81cc64721f2fcce6fb8b812bb354a9e5b20a51b3e176d84dacec7f86add3ed57bf5ef1a87088d1efed84de02e26e1c2a857a78595db0a7ce7bfd8abaa"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "48582c4d7897044f151c2faddd9a139c18e4e51cbe0ea5025dd7e685dc2945d99f83208af25520d03f634711fb0c3870"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "25a462c302d2ae6ac9967ccc20442b51bcde865e4242a1636ddd1e157bb0c7803313722befc6b955d7440184946425d3"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "134cff3b30cb7e2deedcbf6b6311f2dfa6448c4ef81d2c1e72cb2078934d3527"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "0a89b0cab87b1796283b264bd69b742cc287e1d85b3f522cdef10777f7e5cc706b6924232c3f1c071672a4e0120385c65d795753ef2ef93f59757eec42753b6b"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.maven/maven-model@4.0.0-alpha-7?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.maven/maven-model@4.0.0-alpha-7?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "org.apache.maven",
+      "name": "maven-api-model",
+      "version": "4.0.0-alpha-7",
+      "description": "Maven 4 API - Immutable Model for Maven POM (Project Object Model)",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f82d872d0d95c2823f33b7c1056d7bc4"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e8758ae3429eac29f7c2f5a628893e1d6c65c53b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "01b5489914f198da93c66b0c1d159d0e0f948bfc80a2dd36d872b1bc1b6825d8"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "1492c5927f16361214a04b41f6b0da3962739f19cc41e3f29607bc28a8985e652b9d36402e6f3e572490fd2359f5569140bf2434e445de4a162565ede5cdd575"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "e8312689c62cb18c5473a1c95da6bce534778e7f732da06dfdd9ddc8e05660efdc7cc091f0e0df878edcd74d6eef9d63"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "73f8dca1d460eed6b315d42e808d3a8572d001b9d64d52b338babaa96b528b488c9b753a265d946dc833cfb184dc0d8e"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "bc739b71881794b4b27d9d300a49ff842b5183ea7f4c4c3614ff7e91562ce6da"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "579348b292876fc5dfba7d244638bd0b7f23d0567e287c82318060c28b4b1c894750cf590492f05c2d845f1d276ff7b5a74ee9357b9dea36b46970098b50007b"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.maven/maven-api-model@4.0.0-alpha-7?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.maven/maven-api-model@4.0.0-alpha-7?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "org.apache.maven",
+      "name": "maven-api-xml",
+      "version": "4.0.0-alpha-7",
+      "description": "Maven 4 API immutable XML helper.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "eaa62eb9c8cf3e767bdc81991079aae6"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ae85bf0c76a6b868058af3e0ec89c78d9acd4eff"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "3388f4d0465f5a7e9a6264baf506da1b052c51f7cc10b7ce73f09723e6cf1d92"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "111b2f59a4357a261ee362f85d676a2df1243a9641ae0220c5b5956e5b110b9bfad11bb719e192bfc4c7e41a1f336bb317ccf73ca2771ca82666a6165185ef1f"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "32de09cd69086f1f13b4e3884b675da4c5a1baea18aac40e91be51be1dc714797647e2020c373b45191881d8cddea31c"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "135aad9498820899388210a00305bc8f1f38db79c9b0cda3da77fab98c26e3e76ae8e0e2cbcc86113d3a0f8bbec8045f"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "dc3cabac4b7818c64b22197efabb27498c0a18d10d6de3ba9f8535364a703764"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "2f94eb1e9b4ce5f5d959d9a7391505a0b784f398c1d52e9fca5ec2c5c2e01bea15573f23edfad4644c4a1c06ec7c55def500a2ac77ef64d19b3fd4b9ba312890"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.maven/maven-api-xml@4.0.0-alpha-7?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.maven/maven-api-xml@4.0.0-alpha-7?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "org.apache.maven",
+      "name": "maven-api-meta",
+      "version": "4.0.0-alpha-7",
+      "description": "Java annotations for Maven 4 Immutable API.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "0571b58631234946491bc5f7a91d8c74"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "db4b391f5341ef940fb3a79060865b7edda6c6d5"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c4f6f3868f5b280cc7e268f0f95e1bb1d2a824afe92a8029e861be7ec48b1272"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "3ce55d4f065d775f8be0683f8eec5ce68fcfec89217381defb3b6c2a4fd77a8c4d925498f965232f5edbf7795ef09ddce1ceaa7d3d00c321c1aa3bec51a97919"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "049684a7db1a32f07d20fd3daf32025ebb0ffc2cf8bd50624465154a926fbac0687b4e6090043d81f4758d9e1dbde58a"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "f2a37d6204fc059f968b37fe885c118649c4ee652c610ae96a567e3e6d944c8ada7f29c99de9558f3332ed151d2f3613"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "52ec00d515a97b92507494aaf3ac262f4b0e4fd2dcc09bda5e2bf5b99ab2c88f"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "5ee410254883a8f370ab3b299315c0e3378ffb45a05a8d088a08c27dcb13f9e7a920489224cc57dac18726881d5dcd5480d91064c6e5bdc43144f5c03ba6cb96"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.maven/maven-api-meta@4.0.0-alpha-7?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.maven/maven-api-meta@4.0.0-alpha-7?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "org.apache.maven",
+      "name": "maven-xml-impl",
+      "version": "4.0.0-alpha-7",
+      "description": "Provides the implementation classes for the Maven API XML",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ec115686a695a77105dcca8dfd5d40b4"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "06678934d540a73916c58993f09495d53aac1291"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c89323b70dd491a3ef21432dba4cad2b74e26caaafd77178b0f15313fe0bd5f0"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "f97246c1ecab2f7042e38634011a99d07910f9c684b3fd2650b289399612186b656de4a58e27da9834dddf3539ba5f62bbd3ed4a1956ca08992d3fe58c0cf3c2"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "e1bcc2e855059ef52d3b771dd9b96353847b9168867a20c5903cc8e9831e025c9a43604ddbed03016ffcb06bca2e64c8"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "ad48be65408e0cb62e5d879113b7ab64adf1c4205360467b97c7be0cac7568526741ab3ec4d0d11765dcfa54bf334c12"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "b22a31bb94feb8ebfe013ed6e46dee316a6c4711bf399879f8a3fccb2809012d"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "f9e66ddd0f8fd621a87460c925db86b9d4c1053a9086cdc4c1602ba3fc566356355016e2edc99f0495cd13622bf1e68ea5c289712815114562d27c7a2898daa3"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.maven/maven-xml-impl@4.0.0-alpha-7?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.maven/maven-xml-impl@4.0.0-alpha-7?type=jar"
+    },
+    {
+      "publisher": "The Eclipse Foundation",
+      "group": "org.eclipse.sisu",
+      "name": "org.eclipse.sisu.plexus",
+      "version": "0.9.0.M2",
+      "description": "Plexus-JSR330 adapter; adds Plexus support to the Sisu-Inject container",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "98e320df2caac742b2ae33d938c69df8"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "31456dd2293197bb282c03168f6767acca3dec96"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "9500d303ce467e26d129dda8559c3f3a91277d41ab49d2c4b4a5779536a62fc1"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "907bb88258ba9d9ae465db219de803074a677193f3a5a05cc36c7fcf413123f50742bab231d3eb783395448bb487934f85b12972efe36b77a32e235524bef4ec"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "8eb92a65730622e93791bc4c6435113596473d69f3d8dd5348c42ea47c2a93017674fafb34f5d5a48ef210638d37640d"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "e97753b0913e87a430a7e6ce8467a2903670edbc87cba4282cd401137983b15cb9c4361c7504e139bb10119d9d7ddfde"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "883521331173ce90227bec1c5848ffc2f2a45e83eaa29d0376fb80e633c462c0"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "3429abb8aecac539bbf04bd6f6ba339c71d7156ec0861f27de86e1664312bb30dcd076a317dad0bbdefad89dbd03fbcf56003e16551c3320e2bf223424998c16"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "EPL-1.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.9.0.M2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.9.0.M2?type=jar"
+    },
+    {
+      "publisher": "GlassFish Community",
+      "group": "javax.annotation",
+      "name": "javax.annotation-api",
+      "version": "1.2",
+      "description": "Common Annotations for the JavaTM Platform API",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "75fe320d2b3763bd6883ae1ede35e987"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "479c1e06db31c432330183f5cae684163f186146"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5909b396ca3a2be10d0eea32c74ef78d816e1b4ead21de1d78de1f890d033e04"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "2453330b27a0822bba440c28b98ae1d83d60d97dfa2d040562dd5126b3548e0caa040fea3b886ac6feb0a858e6c1bc45b6c5472b180f1f14792e5ca33e355959"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "37a46eaa1d011969d28ff0daaecd67a560169b3ae70c40102331d85a71139ca07110169fe367f484735914ce5c6b86c0"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "e2f8df1aad5867355fd1d3de2374d077e3ad885e6bddac3ce7c7bc72a34097e33bc5dfe960f839a7feb515bd5a92ffd1"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "2e2acc7429faecd2e74c0c441209b1a5b0ccbc245ccd8391425c4b1e4b2fbc94"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "9a28cb34c7761e695ccea04cc6df1e0f9cd18fef59bf50d5943ddc06802e616bc2bd55211e863c65f7f7661f963ba8ee9e569324642b87bc1703dc6f07cba5e3"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/javax.annotation/javax.annotation-api@1.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/javax.annotation/javax.annotation-api@1.2?type=jar"
+    },
+    {
+      "publisher": "The Eclipse Foundation",
+      "group": "org.eclipse.sisu",
+      "name": "org.eclipse.sisu.inject",
+      "version": "0.9.0.M2",
+      "description": "JSR330-based container; supports classpath scanning, auto-binding, and dynamic auto-wiring",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "eb805c5b2e22c8002877f0caadc6a87c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5ace70e1ea696d156f5034a42a615df13a52003a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "9b62bcfc352a2ec87da8b01e37c952a54d358bbb1af3f212648aeafe7ab2dbb5"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "89544822c6c11a165f36e8bc29d9c69c9bcf85635234367cd9e8065273d891d1e9a8118a283502b20d00594db9c123e59901caf118b92424690fd6b3f60f2cc9"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "7c1331d3ac0f1908861c96a6d0d32dcd9bfaf3bf1c0a403e6b69ffa88ba2d1b1deddfa9a59c92be43d443688e1e0282d"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "e9f6df518234899f3f7e82d934c4e66164ccb567f8cf232a234a93c414bf6717ad199d2c6dffd8196ccc9826d113fd34"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "f1646c76c126c31fdbdf4b0833b53246f34314ed3a5480d56d579d29c8759fb7"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "e4d125178fea97856067ef119d2d6864235056d8aba53b57171aefd36d14e4b54d25a417ca18af19f720efb9b32eae4a1d339e79c1687570735f359cad01f5c2"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "EPL-1.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.inject@0.9.0.M2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.inject@0.9.0.M2?type=jar"
+    },
+    {
+      "publisher": "Codehaus Plexus",
+      "group": "org.codehaus.plexus",
+      "name": "plexus-component-annotations",
+      "version": "2.1.0",
+      "description": "Plexus Component \"Java 5\" Annotations, to describe plexus components properties in java sources with standard annotations instead of javadoc annotations.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "141fd7a2ae613cb17d25ecd54b43eb3f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "2f2147a6cc6a119a1b51a96f31d45c557f6244b9"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bde3617ce9b5bcf9584126046080043af6a4b3baea40a3b153f02e7bbc32acac"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "cc534fda54272f074fe9edd581a6c3e1ea98127340c7f852c4b4953a44dad048ace22dfa10f30d6adcdfc15efd319dac778a03ebbe20de7779fd1df640506e88"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "dd102351fada419b7e66f38b62868db4141cf93863b8117926564dd883b4a3960d9c9682b346f7106cdaa2a4138c794f"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "2b335733d7683e8bae312b0608af7c17b1aa22a1b9cbc4cc11549faf6bacc51c7591f1073aac99e5d70fdea31c6253c4"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "2e9f44d1c5df160563d3cedaf01929682fb3e0432beca7c782d8ba0324fb32b1"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "5051e4210310ec60fae9f32284a93da3cff63bf43a7dda30eaf2715d24cfc7f2353a6c2731521f4d6ef32e7a3e2526b6a41c8a11b0889c8dbf7ffc7914812641"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.codehaus.plexus/plexus-component-annotations@2.1.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.codehaus.plexus/plexus-component-annotations@2.1.0?type=jar"
+    },
+    {
+      "publisher": "Codehaus Plexus",
+      "group": "org.codehaus.plexus",
+      "name": "plexus-classworlds",
+      "version": "2.6.0",
+      "description": "A class loader framework",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "67e722b27e3a33b33c1b263b99dd7c43"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8587e80fcb38e70b70fae8d5914b6376bfad6259"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "52f77c5ec49f787c9c417ebed5d6efd9922f44a202f217376e4f94c0d74f3549"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "6a58048d9db54e603b9cfd35373cf695b66dd860bec878c663b4fc53b6b3d44dd5b0c92e7603654911b1f78e63ef277cf6b272fe069a360989138550545f274d"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "e839707ea5c4351f2703c6861ee4d58e08df0f7509110af13d4b3824e6ec5cfd65508fa80cc3f222baf5cf6c4ab5d5ac"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "75389fc7ed9aa3ad33ff317b0d41851fe0073b37aa8c33081722bfafb851493fb0e3b9629f924026fc32841f01399695"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "3aef41be29373137c58c415693b312c95e048731dce519ab88649eae9ba0e492"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "312eff142f86b9e110131dcca69527fbec80478e463fed5a34e2bd628673bce7be9ddb6fe0cda7fab2a119d1f310629413740019e686e9162194984ab6e06bf4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.codehaus.plexus/plexus-classworlds@2.6.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.codehaus.plexus/plexus-classworlds@2.6.0?type=jar"
+    },
+    {
+      "publisher": "Codehaus Plexus",
+      "group": "org.codehaus.plexus",
+      "name": "plexus-utils",
+      "version": "3.3.0",
+      "description": "A collection of various utility classes to ease working with strings, files, command lines, XML and more.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "3ae76ff0195ada460d495efe1fb50d17"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "cf43b5391de623b36fe066a21127baef82c64022"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "76d174792540e2775af94d03d10fb2d3c776e2cd0ac0ebf427d3e570072bb9ce"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "a93038005cd9793476c913beaea7c8c170d1853dddf39bf6794ad6446165eaf538c2c3c2314baa9d919d6b0bda78e5ea3cd987d5dbacf8e3b98e315bcfa7db64"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "27742e2c82c13ffe947c6ce8750b1989491e8a5d7554cc3fa240a952c9d3a22fe006516041c66650e71972275c06565e"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "16af5ee2b4f8710fa14bbd977ef3630466c51c4ed6bf9886ac0ea9c74bd23dedbbce60beae5217fab686777108c2e54d"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "364bfb131dab58736c995ac4484d9eab53b1e62129a99ed55e9c12ed39079dc6"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "4687c5ca8bb73d6880132d7d886733d0a5ce7a873c7b5b68d9d46066ee7e1f6c11f0510a70f313ca2563550bfcf6e81cf37a0c4ceef247bab55d6aadc49fae59"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar"
+    },
+    {
+      "publisher": "Codehaus Plexus",
+      "group": "org.codehaus.plexus",
+      "name": "plexus-xml",
+      "version": "4.0.1",
+      "description": "A collection of various utility classes to ease working with XML.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "33b3cbfce10fbae18749358d9803fcc7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "736d992ca3f42181ae6ddf8d9d184105e4ebd751"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "a5b13d1a8efb8e9240d9a32b7a7da87b5dfff563e7737f7005d334af861f1f62"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "2c26eb899e5140aabee1d592b965a50ee34463d2a86ca388cfb94a5ae4f6514541a8ba880135122a9589566012537c47932687f8e854f4d66779a38c47856567"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "d0af58c3d41930a2bd6a4c998e0b49682fe40632ab2dd700eac1ff41b2de4ce6e7ef03a7cb999d14a393fb5603f13b30"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "d755fb0bbd118738dcc6e80407ab762f4103e0b212d53de9431197a7330231a768e7d7b7137f02c45163fbb61f1c3188"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "28b0de82ff98f0479a497f129de1a9f2ad9b3ae5cd43f4db26794c2fd6945756"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "fb45f6d819422c4b2e7b40a5df4edb8b194080cb6ad6c7079a6f43543dc968b1219392e13f6bd950d1207d2d421cddb6cf77d5e6f3f0389512686e7dc81be265"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.codehaus.plexus/plexus-xml@4.0.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.codehaus.plexus/plexus-xml@4.0.1?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.apache.commons",
+      "name": "commons-lang3",
+      "version": "3.12.0",
+      "description": "Apache Commons Lang, a package of Java utility classes for the classes that are in java.lang's hierarchy, or are considered to be so standard as to justify existence in java.lang.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "19fe50567358922bdad277959ea69545"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c6842c86792ff03b9f1d1fe2aab8dc23aa6c6f0e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "fbdbc0943cb3498b0148e86a39b773f97c8e6013740f72dbc727faeabea402073e2cc8c4d68198e5fc6b08a13b7700236292e99d4785f2c9989f2e5fac11fd81"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "c34b8a0e0eba2168ad56fedeb7a1d710b6f1d3f1ce6aae99a4e0247bd120efbbadc8dcb2f731045b8a16e3efd30604dc"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "8ad6ebe7754bf0caa8cda7e59c0e95360d76e06a7ad6aeec5637985519dbd1dd06e7eed04711039f36ec4c49de280def"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "18ef639b2aeeb5aedffb18dbf20c79f33e300d99fb31b131689639cc470e6e4c"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "fbea96114dcf4f31cfaaa99987be756ddda3a6c74f8c835461997df794d54b92da1f60fe5c3f1f2a43cb8c5f5db7f4048bef77c70993673c7a93f3660fffc8da"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/org.apache.commons/commons-lang3@3.12.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.commons/commons-lang3@3.12.0?type=jar"
+    },
+    {
+      "publisher": "FasterXML",
+      "group": "com.fasterxml.jackson.core",
+      "name": "jackson-databind",
+      "version": "2.14.2",
+      "description": "General data-binding functionality for Jackson: works on core streaming API",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c1b12dd14734cd1986132bf55042dd7e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "01e71fddbc80bb86f71a6345ac1e8ab8a00e7134"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "501d3abce4d18dcc381058ec593c5b94477906bba6efbac14dae40a642f77424"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "85473a29d23292f49092af9e7a7a63993206847c53b3e71f3c67245d68f7b19cc7c341e0ece409eb5e96602df98a848e957d8691fdd2c5fcddd807df9078255e"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "5c54d6c497cb329c3424a30319bf657ea222349eadc5ae74c30e8dc1525d7b60b7785f4d20370267b03343dd738cc13e"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "98ff0b2a4dfc1faf319d4b0d38376c3c7a58b65d071db293232eed810adf2e525fecee3be45c99b41e20cf6a3a8ebef9"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "2dba45f78a0d37402083975e18dbb3201705faf7e533c3e9721b9364c2a1ab0f"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "76ef73198269cfd0922f4ae86c8b7e6a9cd1b96ee55da43ebfe57dd34365cc1c5c5630fadf79e46156a52b6b96b7d1f694f5e4f5c4f6a3d3ebb31c927e414435"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.2?type=jar"
+    },
+    {
+      "publisher": "FasterXML",
+      "group": "com.fasterxml.jackson.core",
+      "name": "jackson-annotations",
+      "version": "2.14.2",
+      "description": "Core annotations used for value types, used by Jackson data binding package.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "10d19982a8890f6eb37557af2f58e272"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a7aae9525864930723e3453ab799521fdfd9d873"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2c6869d505cf60dc066734b7d50339f975bd3adc635e26a78abb71acb4473c0d"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "a978384791bdc074df8039ffc95bb93f0f60d14d476861ee2a0ce208b33a991c486a07345cb80559252c3ff1dea14d3efb818c19bdc18435946dc8754d8e6ee3"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "d5111c69020666689414921ae4a8950f9fbdf86dec1360f6827beeee9ebd3f78db74e69c76e0becaba47eb34fdaaeb5a"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "53b1a8891482e16a7d8849251cb0dcd1aacf6aaa2161a73589d9742ad96763e384d426d04db762e56fc4536f4e719084"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "14f7b3c51c96f7429f7c60a69e3b7e4f9f2207820141f197d56b57018ffd5640"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "75e4e4fb847fdacdd497cf6b340362581ab4091120ccf2ec32a273709d336af0f78c90ce12b2dd1d17354aa08583af0d3ded89bb415720f45f2d9c110d71dd7a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.14.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.14.2?type=jar"
+    },
+    {
+      "publisher": "FasterXML",
+      "group": "com.fasterxml.jackson.core",
+      "name": "jackson-core",
+      "version": "2.14.2",
+      "description": "Core Jackson processing abstractions (aka Streaming API), implementation for JSON",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6ee422ee4c481b2d5aacb2b5e36a7dc0"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f804090e6399ce0cf78242db086017512dd71fcc"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "b5d37a77c88277b97e3593c8740925216c06df8e4172bbde058528df04ad3e7a"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "208953cf72691b3bab1ca2f9a045cccd3d75c46c90099ba884fbf16bc3e45045e5cd014d2c68c96e8a8826f87a5f0e18cb34b35e7ef03348953869c21e197367"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "e806595862c5fcdae801d9845befc1d12c97e6036ee839d34590dbd785a422d5832cf4fc5c7ee6e1a5ee7a59f37740f0"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "4fa59f572f2e100e2eba6fc664a3b9f804fabd911a552cb40805f39e624a9c04246b679cf4b017bb782c8272877f49d2"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "cef17d3a539cbf798cfb0bfa9faffa2b7baff3670b50743e91ee58b4c60b59f1"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "fceeed5cb8fe4335d88282d15657762a4728483275a7ff45f50b9fe6a999757ccb37c415d001eb6250226f98f5c576b1b36a83e601fb393cfd34a811c2df5d00"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.14.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.14.2?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.apache.commons",
+      "name": "commons-compress",
+      "version": "1.22",
+      "description": "Apache Commons Compress software defines an API for working with compression and archive formats. These include: bzip2, gzip, pack200, lzma, xz, Snappy, traditional Unix Compress, DEFLATE, DEFLATE64, LZ4, Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f1e4db16fee4291212d91409313a8086"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "691a8b4e6cf4248c3bc72c8b719337d5cb7359fa"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "53d04a0efc7223baecaa303bd5d298eb0600e6b82b4076f9cecd558b97ba760b"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "2d64fa6cd081fff5d73ee662a82f6186991fc13b4bdaee18b5f1bdcab06d9acb70e3713d18b296337791448251fbd6768bd84afaa817a10547652d0cfa885563"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "295d7f69d151abbd784e1c4d021c77ce43e129bb5bda0c55762b32d77c8607863383297674ec8a212ea3dfe4007b0044"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "af04eb1b4647b1a041c5ee994c2c7a32556b5410b916fedb69905f166938baa43ba54fdc67084205794c02680d3c6349"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "40f2960e82adfb171b0c5430271fdb0c0dae243aaf9b08021df54fd4d4a3a0b0"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "f2c445f77bda3ef230a2b78ea88d86e48a7d6db36805f841d5cffe1f178842a161b2fda0b0d60162af210f18ed9c5bb9579c963291c26f715c1aa389d9a6785c"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/org.apache.commons/commons-compress@1.22?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.commons/commons-compress@1.22?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "org.apache.maven.shared",
+      "name": "maven-invoker",
+      "version": "3.2.0",
+      "description": "A component to programmatically invoke Maven.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ae1b36901af33a03b0ba0123d941b938"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "84fe50eb8183be035f77f86e21c5830e3b19c337"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "51cdc34d2092a47f394b31e0545858c022030b47fcf30de16389c15ce7afd17c"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "64ff1bef0f5375415202497641ae79a8ef3a9b821a803ab10ab03310a59c2bdb1b39210832e35331cd644f3fc987c6b73a7d271fae870fa4b894b7b7c961f83d"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "63f44297c67b8a439a64c0686eee01a38c9945fc4bc007bb5312ca599007eb4e18c3696f13e668e541d896959e5294b7"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "8819cee1d652d87544df852994f8df1bddc763119e9ca1cb33d64617d5bcdcc27c35a63ac06d7cbe5251917efb696467"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "07ad37e3700ae49b4af9ed462ab8fc216160f9a07ab45461fa3e0d64e6c313fe"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "718a2f5b8d165b42fac7a057b3ca9637263cca13870957fccb52e733c537ab36e89e51a1635e67634eefa6264ee4ef0fc650fb4344f41a58cc1f61bba361198f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.maven.shared/maven-invoker@3.2.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.maven.shared/maven-invoker@3.2.0?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "org.apache.maven.shared",
+      "name": "maven-shared-utils",
+      "version": "3.3.4",
+      "description": "Shared utilities for use by Maven core and plugins",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "908f2a0107ff330ac9b856356a0acaef"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f87a61adb1e12a00dcc6cc6005a51e693aa7c4ac"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7925d9c5a0e2040d24b8fae3f612eb399cbffe5838b33ba368777dc7bddf6dda"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "c6693f8a061de74ac59c61d185f5b130cb574405cfc37febb8e73806ea64eea822a4a75c24098fb49b7871373091543a6f4c526c0842589e528cacad40e5554a"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "bc5b42831ff598f42dda54738be004a619d60201a009b04cb3aaa0dc343d0e4fbc423b19739391eb7c33efcac3c08dd5"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "385bebb35d7ea13d92ae6a5afa9257b184a1fcf40cba077a103c7a91d39a4d3e0180a475febdba73ac75949968e77186"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "888fde30d4f9a9e1b7c4c5e4d61f9cf0499192e5bc1212538e2e3320688e44da"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "40b55bb907452777443b8162d456bf1d48e02bfd9124062faed9c9bf51e0f522d40b02f4c24eb39f760469ad226570876f0de6afecd74903112ec794f0aa9a78"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.maven.shared/maven-shared-utils@3.3.4?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.maven.shared/maven-shared-utils@3.3.4?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "javax.inject",
+      "name": "javax.inject",
+      "version": "1",
+      "description": "The javax.inject API",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "289075e48b909e9e74e6c915b3631d2e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6975da39a7040257bd51d21a231b76c915872d38"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "e126b7ccf3e42fd1984a0beef1004a7269a337c202e59e04e8e2af714280d2f2d8d2ba5e6f59481b8dcd34aaf35c966a688d0b48ec7e96f102c274dc0d3b381e"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "ac04c9f03ccbe35a25deb8b50280a0ca01dbe6aff0dd795d55af6112bfe3cd5817eb82f32fb18378d86cd64b07597190"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "fca090ecb1edeacb9fe865dc515cd1d109b323cd742d4a9733ff199a96ee96e0db4f924079520b9c189ef750f255475d"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "5b0054e39e522de0e0ffc4034d12f72270291fb24d94d5ffc9c4d69c25035fc6"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "fb290f5a70b1efc1dff12f40a0b2d7b94019f66da42e78010c0b8e61f222c4f267b67e356a9e9c346eb801e5515e36243888f280c5cb95c2dd69016a30cadeb9"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/javax.inject/javax.inject@1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/javax.inject/javax.inject@1?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.jgrapht",
+      "name": "jgrapht-core",
+      "version": "0.9.2",
+      "description": "A Java class library for graph-theory data structures and algorithms.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ae515025fda476afb55d1edebc6c166f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "2597c1f9aa80fcfdd1f2e8ad0f0655bd768d95ca"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1a28d0c0c06c66e191088e32716c027951da061da0a78a53196e12d47a4d8f7b"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "1e8da60a825fda548d5193b274504f560fb3a208b60a0587f8c7de832c34fbb474f1d6e2efefbcce741c6cca96dc67ba1834b259b21b09576d1d8d364a48c979"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "c0985a618fe01585c086a929c3f1c37e9a06bf0870cfef58b588ab1e8e626c22d07e0a7627fb1d4f004b8cc30a0ba640"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "80d7b8f8fb764847560764676fa66fb7ab7332a1b4e216ca559097f3e62b2ac420865923acc9489812f694f708f74e88"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "9d283bbe145f0f336561dc4633bb362309bef25f4d7939323572132f30c98df6"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "bf40a38261f8d1064b847223f740465287ff50768e760e8d1f535bd79d36783cb28188323f9f3a5a20cc11640c22c52d3062ed9f8575ad93b0f338b73705ed96"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-only"
+          }
+        },
+        {
+          "license": {
+            "id": "EPL-1.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.jgrapht/jgrapht-core@0.9.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.jgrapht/jgrapht-core@0.9.2?type=jar"
+    },
+    {
+      "publisher": "JSON",
+      "group": "org.json",
+      "name": "json",
+      "version": "20090211",
+      "description": "JSON (JavaScript Object Notation) is a lightweight data-interchange format. It is easy for humans to read and write. It is easy for machines to parse and generate. It is based on a subset of the JavaScript Programming Language, Standard ECMA-262 3rd Edition - December 1999. JSON is a text format that is completely language independent but uses conventions that are familiar to programmers of the C-family of languages, including C, C++, C#, Java, JavaScript, Perl, Python, and many others. These properties make JSON an ideal data-interchange language.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "333139fffc6c9d4bc3d2495d9613f092"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c183aa3a2a6250293808bba12262c8920ce5a51c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "055be110a570f9cda3eba8d70a006ff46c77a048bc67868524879211c48b330a"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "ea18db6a9b2db4753bbabfde3ebf2159c0bb71dc8ac5f8a7b6ace9666b0b82a04927952db7c9285ace05301bd2cee289d8ba022a4229550de6ba0099659a37d7"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "02ff7e65018297d71471efe0958bb6a473b32d537fe0d83edf9dd97f494627ed1af7f809c671737119e1567955683f5e"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "3dfb3c199a14d04cf83b471b6db410ca745ec7857df740f0ac9c6d1e838297b683ba83493e25a534c40443c800c7e64d"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "388f86f18d3992eec02f55d101f7017e4c6e7e70d6479a4510cfbff38139f17b"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "9d9248e1690c04bb6168eb647d821489cb537c072c8011eafc10ca033c8565beb26f8662c7959ca96bd76bd0f35b7eb9704ab753a15e7110ce81907a2c81ddc3"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "JSON",
+            "url": "http://www.json.org/license.html"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.json/json@20090211?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.json/json@20090211?type=jar"
+    },
+    {
+      "publisher": "JBoss by Red Hat",
+      "group": "org.jboss.windup.decompiler.fernflower",
+      "name": "fernflower",
+      "version": "2.5.0.Final",
+      "description": "Migration Tools",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6eeba727a5ff6c2239c17169e9bf7e66"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5731b6bee5d807eb46df326a3a8c5362e3e5f4db"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "598321f62b394b01bfd0f2a14dc28ccca50704f64ac15a1cb18fb2613aec3763"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "44db9db47cd14a26e5a81807e0777ecc88aa6ea996cff50d7389ec31af9042629ac9447a646ec10a84c22024685ee43ebe7e5b58272d3d507d90997b2669451b"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "f3d7e41730f97a9b7dded79cd2276973d10cecbc0879c0b47e66e6385a917e3a15d1fc970a18a248c59c4a9b670f9bed"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "98788525b8e360280e9aeff91ab46211ae2c2d7456431c5d2dd5e3c9c9574cc1806bbfa519de47c1eb8110fd80a3f729"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "bae4382ebef36ee4296685e40bf3884ef784b98643e124638c127588eed8b9db"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "e80cde8de53b21e8d94f9cf14298837b7b4048e68310f014960d8af676c4fc713fb6bde7aaed4a86c2526d37e1c31b7b9521a55e26ec1bd5c5c3b6807d0c021e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain",
+            "url": "http://repository.jboss.org/licenses/cc0-1.0.txt"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.jboss.windup.decompiler.fernflower/fernflower@2.5.0.Final?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.jboss.windup.decompiler.fernflower/fernflower@2.5.0.Final?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.bitbucket.mstrobel",
+      "name": "procyon-compilertools",
+      "version": "0.6.0",
+      "description": "Procyon",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ea372463ba96331d00549b6e179a1649"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "44c59529227960fec1be237ac97304303caf0ba3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5b5b40d4bae758a823210c5c1513f2027bd7fe2e9421cd2b004c5d91b0676956"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "8169a3a49a2373420af7e593139b39dae528c2b97ea59c6db86ea1ef6a71911bd1c0657a17ea1831fffc88dea5f00cb96bac9f62ba778f528655f61febbe90f5"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "64fe7373e322e434f5132c0decd4d66feefa529e46d6718de8bda7b5866097e4a23c037255d7a6379835195e2de2d455"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "9aba3381dd0d6ac3145f6b0f62dbd8f06612bb004532847776c70e4efce5fe24a7398d389b68f997562e8732dc115c34"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "7fdecd57c61f781f47e5665804ffc9d9621c161c7bf1ad8b14d2192c988939ee"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "359406041410a3133a567199d8274854ed8bdb92eca7c8566803c814af21e599093a7d75f95f7db79b6669695a3ae275e7a491dcea24acf0f6c96070857721ec"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.bitbucket.mstrobel/procyon-compilertools@0.6.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.bitbucket.mstrobel/procyon-compilertools@0.6.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.bitbucket.mstrobel",
+      "name": "procyon-core",
+      "version": "0.6.0",
+      "description": "Procyon",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ee0b6978fa183455a5b7d9d6d27fe654"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8f5a33f81d7027d11f1eeb609d9f467f97454c1c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e52096fde7ce4c84db7a943298ae6cad4ea9e33824fe6ccb99c308a7ad7e594c"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "689837dee427520cd0a34ba1370cd844994fe092369910d2ccd194c6c78c4ff2f97684a32e961b4323865d1f3cd4aa50e7940868292c91367dbb29b1afde4143"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "50259ac03c97a8235a2f084af16d67019fb80c41481b5e585890abeb9da251ed35477e57f0be19c04395bf45dbca41d5"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "2915580e0589e5e2cc2769ac8e3349d7bfdb995323c2c0626b197499919eb0c5b6533c2fd02020252911f2eb845b0218"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "423fe72ad33d94dc78547b45dbc4b17f4f63a0626be93f5105e6f8be2afdc72c"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "2ae19d0cc4fc15606d979b2577650a69c76d9532a99300066f119ea2c3e31ebba06cc433863eb92cab2fe2bb97b6c99b3bc4bd52ea1e0f1dc567ec1d93c88d00"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.bitbucket.mstrobel/procyon-core@0.6.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.bitbucket.mstrobel/procyon-core@0.6.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.benf",
+      "name": "cfr",
+      "version": "0.152",
+      "description": "CFR Java decompiler",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "8a85ada8cec494121246805a5562b82b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "48ef4892cfe8feffddbbd0ff077735140557db74"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f686e8f3ded377d7bc87d216a90e9e9512df4156e75b06c655a16648ae8765b2"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "6283e9f62b40ba28b6922b1254bb258287b22bd5e7501c0f70174adef136f16da255d87c0ac6c1e95fd038a17fc9521226d937e63fb8da5adc824f2ae1b70a6d"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "ae81993202dae8d0164e5f2632378450dd0f63466242f2ae7994b261ef901672d908acb6dc8afb9ca125bda56ba41e4c"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "c24bea3290b2580a66f3c96f9d6abcbccde8ede506c7958e0696ff2df94ae1ff2af98e46e93cda8b4035fb297e3c8083"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "4b2efdd3d4b24a9cd8a17a79b621469bb94b7049041154a8a17d39010c4e9347"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "e05d21ccefe37b2bc11b90eadf73f7e538113049be00c42bc658de49fa349074a9d01bbf3cb4dc3f7dff87203858fc3bd1c3ef1efa83874c7d4821389997c586"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.benf/cfr@0.152?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.benf/cfr@0.152?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "fr.inria.gforge.spoon",
+      "name": "spoon-core",
+      "version": "10.4.0",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:maven/fr.inria.gforge.spoon/spoon-core@10.4.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/fr.inria.gforge.spoon/spoon-core@10.4.0?type=jar"
+    },
+    {
+      "publisher": "Eclipse Foundation",
+      "group": "org.eclipse.jdt",
+      "name": "org.eclipse.jdt.core",
+      "version": "3.33.0",
+      "description": "Java Development Tools Core",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "5d9e1d93af774ef84b24b215bf33847f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "3c65275f9a04f0b4060c4f71e0d88d854ce64825"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c03cbbf5ab447d954efb8268a58dd9f2fe70f9e5d9be0a8371f79d785357eba3"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "a4e29b68324541a9d5fc823eccd6721cb0d845ab517c7f601f717435cca32a59bd3d3b6ae5cf3b7d723e610172721613737b1f8eb9f3e70f8bd23343f0dbe838"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "b71d58321fff2865da125bb8e8c65f2b0b928551daff43e3c13536ccc976b722328dd692d26e3608c9cbc6a60f9be1ee"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "2c3158f8f9fbf37d73ad26fe554d794ef2fa279d8f81c5624d5bf5c31e95010d73892b0ea46867e0685fad47a199740a"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "926fdacdc856a66b8c1720a4d83a6d85651ae8771fb14db4324c5823bc5fd37e"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "9d94db1423425944f184c4cb4e1c605f54055be2f0ea4143f77c114a51430e4aaa1bae917d8fc7c216329c7bfd7b25d2153c4ff8b130253fdad2822f33f08cb6"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "EPL-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.eclipse.jdt/org.eclipse.jdt.core@3.33.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.eclipse.jdt/org.eclipse.jdt.core@3.33.0?type=jar"
+    },
+    {
+      "publisher": "Eclipse Foundation",
+      "group": "org.eclipse.jdt",
+      "name": "ecj",
+      "version": "3.33.0",
+      "description": "Eclipse Compiler for Java(TM)",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "8f97ca731449b0dd4cbf23aa34774c6f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "4041d27ffea3c9351e3121f9bfe94dea4723d583"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f7686c4960cf70c2ebc5c500a73a8cfc04541b730c18f1c5c21329889b137f45"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "69b57e12aa7f1339fe86fdb82f8fe9a104ff4d5e887448a779059e4f0626c43af0f1539569d9669c3f3add54fce6447e0bdcec93ee52ad25bf9697f7ac59ca7f"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "5d6816535e016403ebbca62356393f1f1484cb8dbcc327cd1f3be9698bfe94b1d29157fe6529770073effbb8da4777e6"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "f5dd816c43b1666a383420b275e47a6d6297ed07393b95e799c0237d42a0ad9afe105b1bbf62979ef6032808309b25eb"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "fac6d26aa92fe8eb343c935c59789939ea02d12327f7c65b0ed95accc01846dc"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "6149a622731bdab696d500f027870a6ab5f37118fca57892b2e52d2a06c4154e1be2690dddd1ed7045b072ee4273cfef3d398156a6fac9387e92a71feccbc78e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "EPL-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.eclipse.jdt/ecj@3.33.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.eclipse.jdt/ecj@3.33.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "commons-io",
+      "name": "commons-io",
+      "version": "2.13.0",
+      "description": "The Apache Commons IO library contains utility classes, stream implementations, file filters, file comparators, endian transformation classes, and much more.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "8d000fa8939b71b8894637f0ef6ea28c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8bb2bc9b4df17e2411533a0708a69f983bf5e83b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "671eaa39688dac2ffaa4645b3c9980ae2d0ea2471e4ae6a5da199cd15ae23666"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "3a5698d0c995c395cf44180073615f087af42fd78e71f224eb38908d823da41f0d04f18e6a14df67b3b02830fbf542f35b9f43aafe39437f17fe18655fbcac07"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "51ce4e22195684565d9a93aebcf93bf9aed13e76e429601bdaf5e348430effb5d1276d848a98690040a4182706c731f4"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "fd396f3c704aacf5d9fbb46d38c93c57ccd374fe0d194fdce9a2a29cf28a49f36546be9a58b525b72adc79f81b45406f"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "fedde8561c6fe53171cbcc97ac3cf9e53803480a6b63413711edba58af121433"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "875e3ef85e1445e2704db29a9d792b1df576786e6a24d4bcc2529eb5677f4fdfacf2af2a12aecf2a309fe76cc67422da05bea17bb1a95b719062d74dd7858544"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/commons-io/commons-io@2.13.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/commons-io/commons-io@2.13.0?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "org.apache.maven",
+      "name": "maven-model",
+      "version": "3.6.0",
+      "description": "Model for Maven POM (Project Object Model)",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "0505d964b102e3f62845f5d4508e166e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "06d73e6218a10cfe82cf0325b582cbed732cc751"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "a1bf0c7856afd1f1b9c81c22818328fb7a796b4047010e08f2e859d1896080a9"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "6ea5f34f4d11524e069716a142140af0f17c7723eec070e33443fab20501e177f265b38c02a324dd50fc2c9d6aa62e73ef537a09e07a9e55282c686b0a905e67"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "fd8129ac75e246281f79a520d5dc7299df8c5b7a3d6f90d69cd56aff6049970619f229df7c28d6d59331c401b01412df"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "0b293af684836821291a16801172a812bbc6cc96bf036c8d69ab4051650aa40bc8d70b2870288c76ad7ddcee391e3cb8"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "6e10d09a9e77a88fb38a2c4f730a73bf9200a0f043511b9ec9d80a26df5e4a7f"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "6bb00967a436512fa8971d57476dada94f74c04125d304d615000e56fc8ce086741ed608c8d14a1924714fac2c113bfb577a6aa0083a3228fb97960749cb076b"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.maven/maven-model@3.6.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.maven/maven-model@3.6.0?type=jar"
+    },
+    {
+      "publisher": "Codehaus Plexus",
+      "group": "org.codehaus.plexus",
+      "name": "plexus-utils",
+      "version": "3.1.0",
+      "description": "A collection of various utility classes to ease working with strings, files, command lines, XML and more.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "bfec331a62402081dd4143e3a8d193e4"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "60eecb6f15abdb1c653ad80abaac6fe188b3feaa"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0ffa0ad084ebff5712540a7b7ea0abda487c53d3a18f78c98d1a3675dab9bf61"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "3805c57b7297459c5e2754d0fd56abd454eee08691974fb930ebb9b79a529fd874f16d40cec66e7fd90d4146c9d1fef45cdb59f9e359fce0c48ac77526fc320d"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "2f2b5f791adacf36428671ba92fff6fb0a6a009f92c8a4b1cc0e3a700edf725152a76b805c77551b24a62e62adc59561"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "a82d71e5de8917d8d5e5553128d7c63bc9465368b193afd167c4decdb4e8468aca4d4fd995f1323057ee1dc66a56fcdf"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "ff5574c752b6f516ae64e7335e98e65a429aa7de738aa963fe25b991cf1ffcef"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "67548a57d26bdb883b0344e129988722e4a02c8732d1d05b4dc5d1cc86fde9d27063ceae80b6a7b94131340022efea994b8bdbbbfa724d4a7a57eb8245ddd989"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.codehaus.plexus/plexus-utils@3.1.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.codehaus.plexus/plexus-utils@3.1.0?type=jar"
+    },
+    {
+      "publisher": "FasterXML",
+      "group": "com.fasterxml.jackson.core",
+      "name": "jackson-databind",
+      "version": "2.15.2",
+      "description": "General data-binding functionality for Jackson: works on core streaming API",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "20ac0d0526a456274409fa852eb74087"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9353b021f10c307c00328f52090de2bdb4b6ff9c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0eb2fdad6e40ab8832a78c9b22f58196dd970594e8d3d5a26ead87847c4f3a96"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "edf622f3d2bb2cdf308875e467f28eafdd581c6ad47992a2b49a2c803b597c7fe4330c8f887687599c8a6a529d8b11054f8b354b7ddddd2bf904ef347d4f1cd2"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "cced300ea06748cc30cdabf1a0a8e45749d3d2a52740975acd858bd13b83458d535a52fc4cc0eb8991ebd3638b9688ec"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "c4a29f5075cc31b52aabfc8f656ee761b075954fe89469e76aef7a563d93ee71653310967b68f89ce25ed26241c0bda9"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "400677b87f766708abe38aea66c8564cb422cd271208e926a0c2eac99b64cd92"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "0a02353d0afa97f7cb85f1f81ee221cf4425fbde1e2d1b6b7bd8fe0d5d2fcb5dbba8b6fe9c79b500c71fdac8accb77eccebe0853fd8c37bd34aa578796b8a81a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.15.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.15.2?type=jar"
+    },
+    {
+      "publisher": "FasterXML",
+      "group": "com.fasterxml.jackson.core",
+      "name": "jackson-annotations",
+      "version": "2.15.2",
+      "description": "Core annotations used for value types, used by Jackson data binding package.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "71dabcaac955a8bd17b5bba6580aac5b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "4724a65ac8e8d156a24898d50fd5dbd3642870b8"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "04e21f94dcfee4b078fa5a5f53047b785aaba69d19de392f616e7a7fe5d3882f"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "c9ffb4cf3e409921bca1fa6126ca8746c611042ac3fcf0e4f991d23d12b20ef0946ef1421d991ae8ed86012059df4e08fb776d96db6d13147c2ec85e22254537"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "78885119a700d5dd717fc83e58bf063e1fd07bc823846b6797af6a04a99e92e8fbcf28c3a1316079e6695c138c110deb"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "f5b8fcedd6d34427bbe32b1c6082b49d9ded5a00b69549cd6722ffad7d87f3e90b48ddc74a8bd0dec1987ebac73df3a7"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "b4e4df4be6fe975483027aef5d4df099d8bf6dd5974118d118a47775d5f75a88"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "d10fdee33fe005f9941851117e7021fae066ca3ddf2ccbbd048dae103f3cb540e11116ba53fe48b34bbab6fcfe09a6cbc6c50d1bc74893509e8b93a6c6f2c517"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.15.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.15.2?type=jar"
+    },
+    {
+      "publisher": "FasterXML",
+      "group": "com.fasterxml.jackson.core",
+      "name": "jackson-core",
+      "version": "2.15.2",
+      "description": "Core Jackson processing abstractions (aka Streaming API), implementation for JSON",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e51fdee85b48e6637ad9e85ee76b58df"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a6fe1836469a69b3ff66037c324d75fc66ef137c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "303c99e82b1faa91a0bae5d8fbeb56f7e2adf9b526a900dd723bf140d62bd4b4"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "a8a3ddf5c8a732fc3810f9c113d88fd59bf613d15dbf9d3e24dd196b2b8c2195f4088375e3d03906f2629e62983fef3267b5478abd5ab1df733ec58cd00efae6"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "22f4b71de5860b9c54dd85091d5b1312f7f5097a376f68f5a35b32a342858bf2e24ed394d76be0648545a6137d78b82e"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "bf7f6d6d6898978d2ca11e924f0268a90adbb6f6f88b1402e7c96b6fba76ff4e7d83ba163d10b1c551443c3b3cdef9d2"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "fa5ecb4b5ab9884403d5001dd368be876e10daf90e91fccfdf6fb21f14563c15"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "1e8648a4c8aac64f0f71787ec6dd4693a30fe0e3c1fb78ce12b2a1865d17d7f9788c085ed1ac1216e45c05f582a0764d8fee44cf18cc90403846d255fe778c7b"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.15.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.15.2?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.apache.commons",
+      "name": "commons-compress",
+      "version": "1.23.0",
+      "description": "Apache Commons Compress software defines an API for working with compression and archive formats. These include: bzip2, gzip, pack200, lzma, xz, Snappy, traditional Unix Compress, DEFLATE, DEFLATE64, LZ4, Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "96b88349958aeaa15cdf6e5e877bdced"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "4af2060ea9b0c8b74f1854c6cafe4d43cfc161fc"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c267f17160e9ef662b4d78b7f29dca7c82b15c5cff2cb6a9865ef4ab3dd5b787"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "e1ee5b7526ca1b6b67b3a6671d13899048f078bf0e73c1e9c601d947dcc9fd5c78cec9592b2a7a586faf4a7fba1c6885f679375cc2f06680a13ecfdad1ed41dd"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "10e49e696c18750c37eee7807aca1ef28fadf2c9da6eabb3b5443bb0e1fa8ebd6638addb2042f27e9a9874495eb10d1c"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "fe9088b53e6a4e89332b61320b31f206b9217f3eb0adc66968a7d82c020ff263b39b686bcef6ef672d14954515edc514"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "9e2ed6dd76655e6c27cd0e4e27a00c32f6e08ad058be4865a33268781484424f"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "30b82c3fe576ed24cd82f2941c5bceccd8ceca3b868b91d0f8cdc2d64ac801101c47519ef4984a7af3b5f1a18e5e87bc6572ac8d21f4b91e689d3cd2e0f14694"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/org.apache.commons/commons-compress@1.23.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.commons/commons-compress@1.23.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "fr.inria.gforge.spoon",
+      "name": "spoon-javadoc",
+      "version": "10.4.0",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:maven/fr.inria.gforge.spoon/spoon-javadoc@10.4.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/fr.inria.gforge.spoon/spoon-javadoc@10.4.0?type=jar"
+    },
+    {
+      "publisher": "Inria",
+      "group": "fr.inria.gforge.spoon",
+      "name": "spoon-control-flow",
+      "version": "0.0.2-SNAPSHOT",
+      "description": "Common Maven config for Spoon modules",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "b13e48b3adbf31428796865e893314f6"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "2fe4cd51d71330315bbf35c953d8730dde05040a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0b1a4c174fb21fec62e04413851e9ab237c9692eaf97bad754ec55d1d302d663"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "b13b7e939a4d38ed5a2893dd39f984beaaac9262dc9d83c8de05ccdbfea6fccb45ee47cea7a2c5aaf917c929a90e5e0a646cffff527c5748afc99996a2196b65"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "6942082af8cca5b8238a00acf25a812e2dd6e65964d4dbe17b8478caa9579d8d395a2e8484899e609dc3695e3e72424e"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "c9fe4c3eec774cd758aa30de730b2af736ea179e0d8f22b03a9439e911423c911e78f4251aab577759190d4c831bf98d"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "9cffd0e3020acf1617e3c9e143d72024196180ce4c8435523a2aca9ef97c8c84"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "33193ed7f8e268f3e5b073a238f72c8d01bd6ea7b5e9f0df21a42a29e5b8aa276199a31d0f4da31d81ea5d40c1611034953f58916acc01a193b7d9d38d2914fd"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:maven/fr.inria.gforge.spoon/spoon-control-flow@0.0.2-SNAPSHOT?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/fr.inria.gforge.spoon/spoon-control-flow@0.0.2-SNAPSHOT?type=jar"
+    },
+    {
+      "publisher": "DiverSE research group",
+      "group": "io.github.interacto",
+      "name": "interacto-javafx",
+      "version": "4.3.1",
+      "description": "The JavaFX implementation of the Interacto library",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e16e4f83beb31ad367b579c6ae38fff1"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0fb20c24b8bff381ddfa826270963b4c6c6cf39d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "fc3db315a19008a46fe9dd9ec1ba08e1948216b64e3bd29c26090b03e4da79b6"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "a718e1e36118e2bb1dfb2ff789d17498d514024c8f5fe3ea35730c55317042f14d12369c40c89c0fe6c41d787d6626d493371627084ee29ee95c9d659ebe7002"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "477ebe43b34836b0cb8aaf7c390a0d0fa7de630837fec4dfd3d4bb6825fda601fe0ebb13fd0380b2b9091040c2c90860"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "076739bee691aca8bfb06ab939b35965b10be4916408c578e57a06fba228b16d8f5c61d05450b4e374a8abefcde5e5da"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "10e6ec6adc9457b6bc0e5c77bba49ee26a7ba666cf8713a19c0a7e4b27320e3e"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "8e965031cce357ec99bfd657658ffcce031687cbcbec8019fa061f3a2aa7ee372d71980444fea4d61c035d3398c32ce71f4e6bd361dafebb2102827d6dfb6c95"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "The GNU GPL3 license",
+            "url": "https://www.gnu.org/licenses/gpl-3.0.en.html"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.github.interacto/interacto-javafx@4.3.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/io.github.interacto/interacto-javafx@4.3.1?type=jar"
+    },
+    {
+      "publisher": "DiverSE research group",
+      "group": "io.github.interacto",
+      "name": "interacto-java-api",
+      "version": "4.3.1",
+      "description": "The Java API of the Interacto library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "594e506e1170b71bd935c810b9912840"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "835bfe17af365ebc70f3b681bbf833f3cd0dac2b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e5fd094108350e048478913782169886b88c4b9dfe062e127ac33a14b7f9eae2"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "5434897c61a655d1f57a3ffe1756572b597faca4f5918327524aaf00d48ce4c86987e8a75b6364b3a86bc9bbfa5798bd609cea41105465387f0586eebcb6eb0e"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "80d0c8e9aaaabed555c5513f77e31d252033892178ca8740d9595ddc57fb946bfa75b5bf64f98e86470683bcee18e9d4"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "6eaabaf7eae453a70080a8743d7ad01763c6d24da577163acf5b60607b1199a3ac47f52ab3f73f2be61c38670a2adb5b"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "25facb23bbf5005eab2499fd01ea13cdc8908890091b13a9fb822fb5f85ac0f6"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "350456575380b30d2ff8d1584fa3438c37146a18749ede48037e4a7a4becf762e67603b3e7140be90563a46c788452e0aad46a4c2c9352d2260dcdca69487553"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "The GNU GPL3 license",
+            "url": "https://www.gnu.org/licenses/gpl-3.0.en.html"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.github.interacto/interacto-java-api@4.3.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/io.github.interacto/interacto-java-api@4.3.1?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "io.reactivex.rxjava2",
+      "name": "rxjava",
+      "version": "2.2.4",
+      "description": "Reactive Extensions for Java",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "24173fb6372874ef8bcde66701880d20"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "16ae5ef44181829f8f52caf61f131af9dfa3064a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1ab516990561710cbda0b064675fa636c1ac497bee3f4c1a84ef00f0c707d57a"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "dcc8ad14a9655021a2c4f52825513dca98cff78cb09b5ce61794ab1c3f2e2e382b36c50725a798a436b80d35296d0246feb28262161bfb322c8ee696e2ff2218"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "177b4dc02cfb3b4839048875f9b788b68403524c82d49b127d4c532673a3fe2659a13fc0ab880f5af8b28faa46e4fa9a"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "8e37ffaca1400a33b358844820a0fb4c75882e482207f69768c5117c53dc75aefbd081727abc3478cada249e5149e7ec"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "0e3609deadc24524b0e6b28271e4a524b75d5474aa6b491945f8de554c08b056"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "48163fd961e7b1a9cdaca540b50c8617e7d1a34122783ffc49a01056b3396e17afd5d6dbb03cfeaf9531d3ae2b16c1ddbe8d498ca38babc75d95fb9e1af353f0"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.reactivex.rxjava2/rxjava@2.2.4?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/io.reactivex.rxjava2/rxjava@2.2.4?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.reactivestreams",
+      "name": "reactive-streams",
+      "version": "1.0.2",
+      "description": "A Protocol for Asynchronous Non-Blocking Data Sequence",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "022ff8ca0101daeb35c8df9b120ff99e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "323964c36556eb0e6209f65c1cef72b53b461ab8"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "cc09ab0b140e0d0496c2165d4b32ce24f4d6446c0a26c5dc77b06bdf99ee8fae"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "873ad9eaf57ab70d9d47a99b12ecdbad60ba81e38c0961262e92f48b2a046ef0e76dafbf76f5766410f406b1155cde94622062cd657d29b0b3ce157f8de0a082"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "6e5860dedc6a6ffd4dd8e7acbdfe655c34acb36f9a98351223232214019c304bac33fcae9c86dd2c980b410e3dc9afb7"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "e1c6e73c4bd681d6eabb8bf5bb2627dd9ea23abc3b00f6ff066dbc5111c173dd687199a1e8b72677c1f4f265fda716ab"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "d0b06ee9e1d1229cd53a532cb6fde41e37112f3f898287c329ee3253692744cc"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "ea12a0144462157973925b78500cb26376b326f51ff8e738226389277b79b118def4c1b7fc189531bcebaf17cc6d8317e31c6ce88a1b197b65a7ddafb45a4d67"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "CC0-1.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.reactivestreams/reactive-streams@1.0.2?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.reactivestreams/reactive-streams@1.0.2?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.openjfx",
+      "name": "javafx-base",
+      "version": "11.0.2",
+      "description": "OpenJFX JavaFX",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "4ee0241a0c0b08dce3cd1093a978f3a6"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "7fb2e4a8528ec9e434a9ac9ee98b39af79e6dcb8"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1f2f88898f54f1a29e2b58caaeb0a11050598a07524f296cd9aef6c00bb93d0f"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "c2a5507a9b74a7eb97f7f0203ff454880b4eadfc8c16b1758bae70958934836572f09a4819259808281cd0d5bb8838a0eff00c68f528f3e85ebb6b5a79e0b833"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "3ccec7a61e6d3475839d6935bbabe7031e0dae0801b284add2d79ed5396f41e7e9920dbf5e0172b5df99668f73567287"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "819d5e0b66f786553c554c4ef3dc2d6be1730d5689a529ab1cac93698a1af6f8976e94225c89e9fc2d6db8ab14b0c0a6"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "722d4ebb03471952bcb821698d7ebb06d0ce053983196b700b7c2f61308c1099"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "f363cc5246e9e4a35450ed8049663c82ab134da243bfc3a2e33aa20313c698a67a27038e604deca4dab2654b553401f5e8eda429e5d9f27047572995bdbaa5cd"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.openjfx/javafx-base@11.0.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.openjfx/javafx-base@11.0.2?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.openjfx",
+      "name": "javafx-base",
+      "version": "11.0.2",
+      "description": "",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "5d688d6f16c83543ef1e8344190aeaab"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8db178adb1085d455e5ef643a48c34959c8771c1"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "84c356f1344bfd3aa74b55a23a0ce078b4c5e6a9be8853da8de415e5ecfcd41b"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "8357d347afc3a99b447115aa402f0dda710e60610560f10551f3bd5b968b19f444903aadb5136aa2a23c356381abe85e847aa7fa8bc00c6747c6e29acac85078"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "380daa338d48176663c7526aac981504fee79f6bc4c2cd1f15c665e5d3dda79a86f9a19fa5a8be3779bbd5ef8d3d620c"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "8ca94423093c8e12ce95c1eecffa76c2b8ddf0ea43d1608204ae9e1c05fffe5d42bb7ac72aa1e52919d768de6a8fcee7"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "2c14b1e93fe70143ba65d23011204aaa7a75aec1ec53f4bae538d88c1d7b24e4"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "1ca3dceba7083289e359be64c02b9ee70210db07e3d124ba9a93baaba7b4b8cc7682136109ad5f7e815a17ac3b8ea64a2c5a2e96341e681028f821dec77f0b61"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/org.openjfx/javafx-base@11.0.2?classifier=linux&type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.openjfx/javafx-base@11.0.2?classifier=linux&type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.openjfx",
+      "name": "javafx-graphics",
+      "version": "11.0.2",
+      "description": "OpenJFX JavaFX",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ef2e5000f111eff7c820a0c18b7904cd"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e522eb4ea422eceeee207b1c266ba3db19b2343a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "dee900a186a70bae8266845c56b03ad9a24e697cb52ba3da421c6049089b3638"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "beca9805509758bdf9a53baab723363cb23b224dd6e1f91b5ce8aafcb990e9e42df7e2af14fb24a523a9f83e990b9bad6fe43176f5b6d833c3b88c73f5d3c511"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "5e69bbb4de344b39366ab331d13bd2286a29236066c18a13e88288a343ea4ca4503518cc33be159f6ef251081cef22d4"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "f5d2fda148db7c08c41b08a7c2f2a7add1879cff2598c39bbec43aa41f8fa98a7834deecb1c0c110981fb3313a05a3f0"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "5e16be7da2bae39ee1882a8663d037283c09636be9ee7713cc11be050ca66c01"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "abfe756705025ac637723a60c61192dec87c3c75cacd114e16df9e9a30b26696049188dc836e0629b307d55bf54c5eb071ceed8b6c3a59b3c61683718e97b0cc"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.openjfx/javafx-graphics@11.0.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.openjfx/javafx-graphics@11.0.2?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.openjfx",
+      "name": "javafx-graphics",
+      "version": "11.0.2",
+      "description": "",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f30e406c342ef125cee349ecd95e3b18"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ef4c34f0ca77cd99100b76c2ccf1dce383572bb1"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "fb209564e50de3d8d055d9b3cd69d46a16d3ef18ec55162fc1300d1408a9d502"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "8b635c0f226ff0cfa9bf7fb40185dedd6345a2fb5427d3b251fc865f00b139e6d734edc0f47e250cef69e2bc0fa9beb531eebc61f329a02151e037f75b061613"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "ef406998db2576860d4200f993416337f91cd18d3565e815676e7f57402c45371acd4fb3fc3c2c08658553d010f62244"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "309d7c8992720433b469516db6b5e839a18ac6ba4e08fe331afd4579c93602cad624baa2a1ecba7a73567293263e9c20"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "a788d8757b3766308dd5fef49a1685961a4e9a1864d950668a69f7cb453b9454"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "656dd23ae8e1a0a4390e9327003fc2bc49d1de7f4c5d61d645c3a49f65514b6612bcc8dffb5a6ca4bde2706c9278a012121a6536036649e7ff8278e67b0ffbcd"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/org.openjfx/javafx-graphics@11.0.2?classifier=linux&type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.openjfx/javafx-graphics@11.0.2?classifier=linux&type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.openjfx",
+      "name": "javafx-controls",
+      "version": "11.0.2",
+      "description": "OpenJFX JavaFX",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "8e720530c3f14098cc96a6df94eb8194"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "4ab633cf1eea60f76e2ae9905aedac862da88b08"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "60106c2cf52a7f31eca1b8d08a952cf4b93b5b1d85492a755e97a0808a69ff9a"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "767e3ce4314e4e6122bbc122e4cdc3a8cc9382a9d62f30794becd3b56987d11091374b5e24d93d3a3508b32920436c4df5e7385b5c4558ce70a9b3b8d17718aa"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "3e52c310ee58bbb41479f1aa10c17903c9a5ccbe56fd936040b5fc9612ebfbe5ec47d18e43cb7999d2887f64ee3ead64"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "f4d39053c3856e58f1b26a53835215aa8d0d180875b30bc5b443461b8f5a72c7fcf581b32619f1242224960ce3ac7315"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "a55eb84ca8a4d464b6a863866487312cfdec823fd51d04601ae463bde5041efe"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "8454c03d082729efd66dea2165c654aca966d6babab81d69527b08750af906b26b6eccf35db5d715425ba72130cbd9ce40c7e3c8aa4cddde13274ad2eebfd4a0"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.openjfx/javafx-controls@11.0.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.openjfx/javafx-controls@11.0.2?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.openjfx",
+      "name": "javafx-controls",
+      "version": "11.0.2",
+      "description": "",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "39f5e9f0f3f9998a0ba26dee53b407b4"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5f6929050a744aab39ebfc1e8e5dd03bcd2ad47b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c172042cf4ce77fc689fad6559256b11b99c6fb89ce5fd1b33dfc344b86a0a97"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "9190b41e0640c4ca20d1a6c4d3eaec5258765929d7fb5078a941ae31058901ca8935612ff8e60d507ff0f16e01c6acb1a66129aa580a0e7c8341bb56845b9b4d"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "44ecbdd7ee7f38e7099758992597932c419f949f321983241d33a4ef902d87965d89dccacf8b56ca97e07d7ecea0e767"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "5fb6b416920f81a5751582ff39546c758ff060f2e4ed7322ef07e213ef2db6ea862924b619099de4270e4b0605affaca"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "60c70a80c07aa53846ddc0dcbb99e5e8c5c1123424981ebb311900a9627c63bd"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "139a5f33d9863d1ab45066d50ea2d41048f2d6d6802edd2bf860a6f478e967df0eb787ad0440064ddb32aeefb9fc80cef5ea5e7853fa2526d6bd799a43cd8b30"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/org.openjfx/javafx-controls@11.0.2?classifier=linux&type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.openjfx/javafx-controls@11.0.2?classifier=linux&type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.openjfx",
+      "name": "javafx-fxml",
+      "version": "11.0.2",
+      "description": "OpenJFX JavaFX",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "170a41074a02276bde9e9e4fa9d6d0ab"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "832f0f438dd84d67c0a473a22d6a03e00eea92d7"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ca22d230125e44bbcf98c0c159bd2c6668b1ea4195f233f52621d30013eb2432"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "de3b21d8c2494b5e1610a0d4cfd4f2c91fd55c66f5b46c188e529a0ae6c0e6da209b53143d684fad27e40e87bda7855036f517db91477d9858ec3748dfe7bc2a"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "7d55f24c967218e0a02c4f33d5a1a9a464a24ee1e368e60889c388b94586d9858e59a0c094b2d370a3dc623f9c76e0b7"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "c7919d384c2d587311f446755e0289205ec58a3fdec88322b26cd3f82221d5c81262f5709e981bc18e0b108a5f40529a"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "dbc36b99bdc1b44aa7790deba0ab77ef3b76362c33b2754c75df9702d350b94d"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "8cb169b1d14fab78d6b647efb4940c01a009a66dca35b4a0031df37bd01fafb67f092121ebcde2233f7a4e2d37efc5c6312690f72ba8d2d980581e2adc0c7af7"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.openjfx/javafx-fxml@11.0.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.openjfx/javafx-fxml@11.0.2?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.openjfx",
+      "name": "javafx-fxml",
+      "version": "11.0.2",
+      "description": "",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "b45643ea86eb5d98f9a8b808dea5e9e8"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "1b8a331d5f393b48de0aef59b3c967a312967290"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "22c44b25bc588df6623e04fa127b8bc82423f1f948e9aff2485af4a6890e2f94"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "aa7a0e0dbff68e7352ecdff0bb546b2a6428ba142bbd7839a2f0c60bd0d6a4015a399b1bb73248a09e4ec161f5b1c532297f4c4f5523680645d498e966810648"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "6c757c4e1220443292f10a9df0df4e8286305314a54f362832066223d670f7d2164845d259406978d8805bcec14c4f58"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "009cfbd51387028094d0dc4a8511e10c7df9e45bfbf4ea84a1b6a4b4214ee385023e8921bcede4ff90e5e7f6731c0799"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "22ace613f77ca99f5d84e1abf91838f3edfbdc48efe3658627fa7323f7feb3bc"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "62465a19399fca0b20821b6de3c9d11fb59d4ecc0e6b86796c205c85587b7d00e3a226069f4f33f48f86167a31d61c29f0ce984dd1536e0b9e35bd6eb387871c"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/org.openjfx/javafx-fxml@11.0.2?classifier=linux&type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.openjfx/javafx-fxml@11.0.2?classifier=linux&type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.jetbrains",
+      "name": "annotations",
+      "version": "24.0.1",
+      "description": "A set of annotations used for code inspection support and code documentation.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "63ebd6140ac340babaf89a754c359596"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "13c5c75c4206580aa4d683bffee658caae6c9f43"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "61666dbce7e42e6c85b43c04fcfb8293a21dcb55b3c80e869270ce42c01a6b35"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "ac5879c0170b80106962881ed2d9a3d5f4b4ef0f6908806ab19c8418fab3b59e2dd7b5f03eb434544119c92c559bcab52a50dcac036b01ff4436c34411f80682"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "52338a19758dc8b338c7081621f60cbc27ac4c348cd28dd544c62f44cf74ddd071cad841c5c08ea9ded19bf5e320ad98"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "3f385678e497872ab6b48227157731f46e5513a6deed2dcee48554a6c5261a14fa904b1492338ab509a96f74be06db9c"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "4b53d608f321a21907aad92ea632b11f466ff9f6d7058a423b72e348480b9b31"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "e34924c8b55fec11f3274e89562ae465eac73035f864ed292aebb8beeef1e133062f3baecba754c8111f6d1c6029fb99c43c6c4c26bd8d54280c96caa5a50b54"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.jetbrains/annotations@24.0.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.jetbrains/annotations@24.0.1?type=jar"
+    },
+    {
+      "publisher": "Pivotal Software, Inc.",
+      "group": "org.springframework.boot",
+      "name": "spring-boot-starter",
+      "version": "2.2.2.RELEASE",
+      "description": "Core starter, including auto-configuration support, logging and YAML",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2871f29bf58317e77907f49c9913b82c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "1f8bb1e33a900c95dc31011e0998b70929d05a68"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1a42d8e35c2f00b7ce751e8a6e11a059a58176c5a97ba76a11673485d7e16812"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "2c4e2aa7661016cc8ed7529ee07780e68108bbf62da36cb7997c08866df29af8a1ce6ae8e1008effd51673db2205f2f7b8cffc7371803a9216a7c5ab8de7064b"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "0ae1782a721633d3382c07076790df8d6127952d3555868539bfc3124580771fa2fcaaf79035d2dad276275d4f6cb96d"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "652dcb7b089453387c8747773f717bcbf68d7a167ed9f47a05822ddf9194674e53d5317a0237e1e100351e1f255e8497"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "ab5142ec4ecba02513bb0f43aaea5013d6bda6515e71e51db9c3a11eeb3f8051"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "93986c1cbf97afccb9d5c26bd15f1c01217bb471e7f8dfd4c69ed4590cf2cc552c1ecba7ca8c1a43f485c90c323923c3081cead6ca68db99b4e29943703d9704"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.boot/spring-boot-starter@2.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "Pivotal Software, Inc.",
+      "group": "org.springframework.boot",
+      "name": "spring-boot",
+      "version": "2.2.2.RELEASE",
+      "description": "Spring Boot",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "92d78e26ff34c5b508f82fda173e3b17"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "cc636f24a5ebbfb21f1c8c30ed9c3b13512c16ec"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "17c61775a96aa2e3b0e9da79ee194f60828c45678f161a68e32e8b60e2d7009a"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "61754759af4ea7668f1fc8d9afff71581a8998953a90637f63449a18ecf3b7fa09e90c3f8487c4dfa4c1b4aae3d7d8c5a49939b3ee4719a56b3bc305f2502b80"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "f446f676822682b3e1f9d48e5e8608427f1dafa3445c7b71759bc70217ba22cb17397ec58d3cb8f0bc9fb76b1b9261ec"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "164759896b618e02413d2f826dbe58859271521f379a597fc32154eb67a793496b8cedc5c40445d6fde9a13d054e432b"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "613c679ab7a082e0b23e7d3ef994c334a02c47fa316e22ddc27de66ee14214da"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "46debc0279c351a2e8fcfdc1361ddadd33e8b0735a3e09ca2a8a39979766ed9e4203c61c8c278f4d8d1fc9090e1dfa9f4366edf7f829c5e28ec0238bb3010a6c"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.boot/spring-boot@2.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.boot/spring-boot@2.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "Spring IO",
+      "group": "org.springframework",
+      "name": "spring-context",
+      "version": "5.2.2.RELEASE",
+      "description": "Spring Context",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6e8cd67b25cd9796d4b193cbddf24261"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a77a18fa425eba9c55447fa0711e2dbfbf71907b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bb9ed510c61e44b4d39b4e27eb6dfa1737914ee10e4d915a9d757114dbd01fd0"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "fa16e8ddb76affe06b1c6ffbcaede53b7a746cec1b9f0b4c80747df5def41d421f8f6d12d6e915ebbdaea27517f2a3ffb95d27cf1313f883c6ad08b5688c12e0"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "c253f26bd996905fc4048204ae78186382ab9a3feed0f2e3927268b7033b19bf02a8dfe8ef70814338ba6b5dba355fbb"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "d78f5a735472fb144f2c279d8496eddab2c034e99febde39af449a59a3cfec400d8bb1aeae358a06e208c15396250e53"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "f26e722f41f502b1698a83ea20d184e445c36f97732158cab8d8a83bc413020f"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "beb73c009038ccc1193c94a1383f9dc18840f3d519f9b239471d320273698507bf5952994d98d5187286ca9a3e0d168ea5b15c71747b592ec0f1637c8358b206"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework/spring-context@5.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework/spring-context@5.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "Pivotal Software, Inc.",
+      "group": "org.springframework.boot",
+      "name": "spring-boot-autoconfigure",
+      "version": "2.2.2.RELEASE",
+      "description": "Spring Boot AutoConfigure",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "dd29905d16e949abb5c2218249f7664f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "2e7876e237097d36bfffd5ce3416930f6d6b579c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4a7c5e6a0c58f329aeedda17f2c2b6b750d9c77c3300b03d807f750818f7a2c5"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "40895b5ee0d15fcd269e71506674a7e99ff2ae8a898e5f4ce453d88320dc569e91d7a53854c0d5cec5babf2311572fb9f7cf8ae2161abdf314a86344ada78f2a"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "169345642075e4e3c5ed5b63a650baaf5d4d13372c2727107d969a8ccfcccccaa4f20b8a3a28157b298b685739354517"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "d6fda50869abf1faf0f4d9946ea31c238fb2e7860763e74e296805aba274619eca3ec190404788f4ec6ea65dc9052a17"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "9d3d6cea4c835bfed48915110a31530c1c12d86e28217e4ce65a37488befebfe"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "e4b64686e14aa3b2069ee16035ba8bc48dc7ba41a6c069cf3662b9cf1545015c6128d366fceb834f6d6318b9637c29a775c0deb3f72b596b51d491c5159eef80"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "Pivotal Software, Inc.",
+      "group": "org.springframework.boot",
+      "name": "spring-boot-starter-logging",
+      "version": "2.2.2.RELEASE",
+      "description": "Starter for logging using Logback. Default logging starter",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "29bc9ee23dd7ce947c40dc8887f72369"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "dd6b1771f1b3288b332cd41705aadcb2aebda221"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0735cdc388c6cad4e19596f9b110addf87c75fe908115fc12566c0df53dd69cd"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "e367a7455ce8cec889b4ed1334f18a9624bdd1756102605239a52cde9b6de97f56c19782f78f65de4ff04f683f119061d42a9c7a06c28cc6176ca452daed8d83"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "2b5ee0773326e0d596ee4614a45bee92abea33a230d921347ba9a667ccb85351ba00325dfe0bb61ca669ab13eb96a124"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "22d9b049e92b5505ad1b021f71bfe9390a4daaa61fb354a0e7c95d7450aefb7c806b00e4e344d5425aabe44d1ff1bddb"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "2d0a625b40be8e453340bbfd9199d9eb0baf43b33167ff0e3992dfc1ec6f8472"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "bbeeb6053e7e930e0b1b347c442ad30ec42d19d7a8d1233b9a9dba8551c98351f9891097a8dfa9bc74fad2f56bdd5537ea8aef60640b0e7c94454f2ad1452fcf"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "QOS.ch",
+      "group": "ch.qos.logback",
+      "name": "logback-classic",
+      "version": "1.2.3",
+      "description": "logback-classic module",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "64f7a68f931aed8e5ad8243470440f0b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "7c4f3c474fb2c041d8028740440937705ebb473a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "fb53f8539e7fcb8f093a56e138112056ec1dc809ebb020b59d8a36a5ebac37e0"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "9ad5df9055e74c1db67e10422774e740903477c821591702d2709a4c1f73e3fc3fa6b1a871b6985901817bc2bdeba916849035dc2bbf518f308637b0586e36f1"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "42a5975c9db68045fd2d662f5168df6b19e5e8b715401fd5786325a02f531b44f1cf4e64f69f5ef5bbef70929e1d6fd3"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "5085a62b9616b811d2346c81aace07020cd7a8865046c4bffb0137f8120c46340741475d83a7c1b4fe1889cd83f774f5"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "7d38586cfd6e1363970ac1811eb49dd9e535e2d2bf967118ce8f28592655ac24"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "0a47917a6adfaef45e1170ff419800a7c88771510c6d5744b081e0572f70d2e339a5bbdd9b0637c2ecfcdd49a095c856ec293e8a41bbd03ef9b5a67d42731e67"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "EPL-1.0"
+          }
+        },
+        {
+          "license": {
+            "name": "GNU Lesser General Public License",
+            "url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
+          }
+        }
+      ],
+      "purl": "pkg:maven/ch.qos.logback/logback-classic@1.2.3?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.3?type=jar"
+    },
+    {
+      "publisher": "QOS.ch",
+      "group": "ch.qos.logback",
+      "name": "logback-core",
+      "version": "1.2.3",
+      "description": "logback-core module",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "841fc80c6edff60d947a3872a2db4d45"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "864344400c3d4d92dfeb0a305dc87d953677c03c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5946d837fe6f960c02a53eda7a6926ecc3c758bbdd69aa453ee429f858217f22"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "bd1a7512647fe61b90cfd18bedf2a33f3f16f334f8f8ce947cdd353c0b0b7a7cce203070f0d2183f6583e0f2b2fe6e0b12eb93bd5b2dc29076e7b466447f6dc5"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "2c34d2bc4c85beee3d82b7aff9f351615a1de9a4f1e262c6e891136a621a3ea27296fbac399398aa8c1fd857fa38393d"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "f511c84d1434e12c1c220d0ec3300a8c5fa3f23b2026c74f2d63be08af02e209ebfa28bd4ca18b0c0557c1e3dba77359"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "7e43423025fc6ebe94b4cc641dc60a4507f93dd1445214847a069595f7cb728e"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "76a7f8df50903e80c5455da2307705f1ce08e098b75d02c1e36cb8b06eb3dc18c4e93fbf4ed1dea143d73645a652b52bb26e789d1fa111866c54a57c2025049e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "EPL-1.0"
+          }
+        },
+        {
+          "license": {
+            "name": "GNU Lesser General Public License",
+            "url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
+          }
+        }
+      ],
+      "purl": "pkg:maven/ch.qos.logback/logback-core@1.2.3?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/ch.qos.logback/logback-core@1.2.3?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "org.apache.logging.log4j",
+      "name": "log4j-to-slf4j",
+      "version": "2.12.1",
+      "description": "The Apache Log4j binding between Log4j 2 API and SLF4J.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "a6fdf03c03b6f5fac5a978031a06777e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "dfb42ea8ce1a399bcf7218efe8115a0b7ab3788a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "69d4aa504294033ea0d1236aabe81ed3f6393b6eb42e61899b197a51a3df73e9"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "b719dd27656646f4db3d99c172a77160562ed6a95f387b938236e696593c30c23411b037935135b3e4193b660a349303c5d183cbdc7288d23553c6828455ca2e"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "cb8bcd02cf60aca12909746f66978e08cbbf56d242a86341051ab82583465b3cd94873e327ccda55138027b9e928e5e1"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "84830b5d01cece9f4cd5923a22250b5b22019c869c874fcbe26be0d29a34d41a1fae4ca626d103858448c3bcd50b6b75"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "654c671055ba21baec0ece0db1b777da54e69b892549c065304df131973b7a46"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "aa9e467bc412e04bc14877d019c9dacb5aff3307e04a432a133b45be12c627f8616115ed78f76ea6c72feb89d60d6b59a7f6ceae5ff0c0c486105fba17865ba6"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.12.1?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.12.1?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "org.apache.logging.log4j",
+      "name": "log4j-api",
+      "version": "2.12.1",
+      "description": "The Apache Log4j API",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "4a6f276d4fb426c8d489343c0325bb75"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a55e6d987f50a515c9260b0451b4fa217dc539cb"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "429534d03bdb728879ab551d469e26f6f7ff4c8a8627f59ac68ab6ef26063515"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "182fd4b7b2642be8aa3c9c3a78a7401670fed6c404596fc916ad21ecc7ea5752d3cd9572f135f0510db958b867f8eb7718ec66ee3d317da6e06201942d12db2b"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "8f30f5cd7ed9bc04c935435932303791a68889c28b8c91fd0b6ce3824563bc2e37c5d6818d30fe4a55dcdaaa32773f5a"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "f54185a012c165bc0268648f98ea883a14405105f6231a99b69f2a4d8426c931bfa1858bba0b10f0997c266f9d057b15"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "e6dca0aa091e1aeaba86ac3fe201635f52f51da1187e79c7a065f9187689d466"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "36175497c2c53c0fa9047ef6db1aa4f94fcd79b23bc37b6ad3c4addee6986dc9450fff6038cd859d8db3a1a6906a0a41e782481066028db857ee256ac07ecfd6"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j-api@2.12.1?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.12.1?type=jar"
+    },
+    {
+      "publisher": "QOS.ch",
+      "group": "org.slf4j",
+      "name": "jul-to-slf4j",
+      "version": "1.7.29",
+      "description": "JUL to SLF4J bridge",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e98450d2de8fb9ffe4fe2f4994462fe1"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f58dd9d8c15a1141a48de53d2d6b723ae6cf18d6"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ac6f86a0afe572c505c88bfd8a79e86b3508926d8cca14533fbda8cb83634a26"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "46d7e99097bdddd63156703125f7c177a189be89e2ea54b19a638905ce9e925efaf07ae50ba9cfc798211ebb631f5c6e37e426f16c884aba23d5204e072c43d0"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "697195fec751dca09ccd020f046e570e3afa18741e095ab045f2e37eb68ed3a2c5b19cdb0ae8fe33b8ff56bab8bb7d36"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "ac6cc6afed5b2839729c28e5791e9030d28ccb0ab5183ed0307cfe7d553a983a3a6fec595ab3aa20e42b3996de6298fc"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "eaff4afc6a431f80a176a75df2ad0e1840e5ff7326083e087dd3a6d2a7fbcd0d"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "ced50e035075e8a76d32135bc95d9e276b4bfbf0a35c18a318fedae436f9c576c73da150869159242ceae6de2383b4679a346ee727356cb3cbf5cd33a97836d2"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.29?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.29?type=jar"
+    },
+    {
+      "publisher": "Eclipse Foundation",
+      "group": "jakarta.annotation",
+      "name": "jakarta.annotation-api",
+      "version": "1.3.5",
+      "description": "Jakarta Annotations API",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "8b165cf58df5f8c2a222f637c0a07c97"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "59eb84ee0d616332ff44aba065f3888cf002cd2d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "85fb03fc054cdf4efca8efd9b6712bbb418e1ab98241c4539c8585bbc23e1b8a"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "d1acff146c0f9ea923a9325ad4c22ba2052ec474341ab8392abab7e8abd3ca010db2400ff9b5849fc4f1fa5c0a18830eb104da07a13bd26b4f0a43d167935878"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "004a4bde333c0575f72df1cb9cf95ee0c6c7f738a6f0f723a5ec545aaa1664abeb82f01627708a1377e3136754fb7859"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "abcc5b1fbad59b3e9b6d2d6195ec11d6254f689116c534a964724b61f815cca60ba3a2c1489933403f3f78dc54fd20a6"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "3d3ef16365e7a0357d82f874fa26b2b0a146cf7bf98a351c65ef1586444fa009"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "88625a8811be514851209291344df32478b527bc7838ddee58752269bf2457ae8f4e6b6a0d0b5c18522e287ba6df1def0cb19dee2b85e01ee21f0b48ac2630d3"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "EPL-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar"
+    },
+    {
+      "publisher": "Spring IO",
+      "group": "org.springframework",
+      "name": "spring-core",
+      "version": "5.2.2.RELEASE",
+      "description": "Spring Core",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "af31f2ae937e45b71fa038cc0c010019"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "bfcf2f6d0494d89db63ae170b8491223c93a88dc"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "94459936895f669c8bdd794be79850b73a9b980cc01a4aec88f373f150002b70"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "caed48b4a6d3f6f6c3ec873ed321f0f4b50715c25a585d073138ae224dd36f2ebc11df942ca9d6986c0ede65aecf25a75c5ae663b8b91ea33eece05b6cc39dac"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "8e5c924657ea1b0f70ce1cef4317157e5a37195a8b785990e46b2d41826114f7700ef3dcc7b8ef724f56a66861958be0"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "3652629bdc4e24ba90582c516a083575dd1dda585217b3f3facf47af96a773a5e27f6d43a969a0373b3167c55d0f4922"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "2b53cf4c06a282856e88212c7292fae8a9ef2173517fb0eca93090fc4ca16eaf"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "78a34b548f685b4a1ff8a14d15ad778f319fa19c96a087ea717db69cf8f9575661c1d41a9fc2935c5b31622111033ee8f2d1b820c30210a43df0d92f2733d7b5"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework/spring-core@5.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework/spring-core@5.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "Spring IO",
+      "group": "org.springframework",
+      "name": "spring-jcl",
+      "version": "5.2.2.RELEASE",
+      "description": "Spring Commons Logging Bridge",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "eaccb423ee1c9f3cf57f1715393147e5"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "35efd564bf664c0bf53bd336b583391a7f872da7"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "db6ec0aa5330ab84a78933fd2c27db83581e3f0adbc1a562013c8647b3935dbd"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "9a054fd5fbf9d613c41e8e72b2bdaf5f3f345ba49d8db87a1466ec1901fc9169aa211407a8565b73e7468679fdec9da64d6be45df3fa814bed7781236b615e40"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "ffe3e98486de633174a79d9075d1c83cb0710d2dc0186ca07c458e4407b170f58f58b4c1906a417963918f3e663c75d3"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "337a2c5d61a5db02a61064eeaa8316833296c9faf8f55f56168c86b98abcb860e79c0bd8e58fb1fe85f5cd45e1517e6a"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "dab8fe8e7ab09a832d041292990dc4d07ce49d27e2f92412f117b74f849a7bbb"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "8ab8e5dfda649e008d3b1a89053907dd30c8caec8834783608f671411d21f9ea452b10dfb6aec031a8b41cee619fd08caa8588aa93842e17ce4146d7b4412d3b"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework/spring-jcl@5.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework/spring-jcl@5.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.yaml",
+      "name": "snakeyaml",
+      "version": "1.25",
+      "description": "YAML 1.1 parser and emitter for Java",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6f7d5b8f596047aae07a3bf6f23a0bf2"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8b6e01ef661d8378ae6dd7b511a7f2a33fae1421"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "b50ef33187e7dc922b26dbe4dd0fdb3a9cf349e75a08b95269901548eee546eb"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "4322e41c6fc5114521da21787ab313fa74bf8449ab0c23ec830627b8121504f70d4522e880aec64df227164729d40b2fbd9670e3a046dd5a5aabc1f71e91c16c"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "7238a64f21ab6c5b4a6cb107eca0b33412c0234e6c0f9ab1a2a8084e53d520c701c318942202acebd162fe9854c63489"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "5ba54baa0f16756d7fe35b6accc7c0f9152489addad5469eaadefa4626316993a66bd45d290a4e80a37bd80b9f03bd81"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "070c462dc2a31520f1dcf69c6fb5eb84d4e4ef69e5face62f758608e54553351"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "b64455bc4317fe5cbd5f859b3adac2d2b2ccf3bcf23aa4b4522e0cab0387cd315f5286c065771ec10db94d469bbecf59f694a71a7eaa674ac031fa380a91632d"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.yaml/snakeyaml@1.25?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.yaml/snakeyaml@1.25?type=jar"
+    },
+    {
+      "publisher": "Pivotal Software, Inc.",
+      "group": "org.springframework.boot",
+      "name": "spring-boot-starter-data-jpa",
+      "version": "2.2.2.RELEASE",
+      "description": "Starter for using Spring Data JPA with Hibernate",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "446f0e0cc7a59b5763d6bc0e42d03431"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "70fca038c1bbb1e9d0d6bedd1035f091ad024a7e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "87d7c86d870e83ff1e8dcd6be9d136154c461071860063c8d228bf4ca8a57e50"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "33ec88f87d906ebc339fb049af851f8855fc19d29af1b4d2616ce4a3e97e44869caf5d9434d4abee0ac7a9c43b15e7b2d92f1f4a9f769f0b5fb5e7cc1c5a878a"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "3356072151db919e915737203129b49ff16c09066e044deb1c151e07819bb59ae0c849700180ce542ec6ad4c5f78a9dc"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "afb579d3ca13355f283a3b3b7de7cd3d9b2abf84aae394f046aeeb50e76099497521ff092633b24574ebd7564262e9e1"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "19a3e975f709909641cdf20cc6ee7bfc58195c65bebc7539ca0aaa3fec3dd80a"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "b621636f652f8111a4048b211ee3a6b996b2472852955ba5b45301277773b4e95ddfbd595869800b8621f568a9a47b7d8a6dbf5e72a6524b8d2cfd4de8308cb8"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-data-jpa@2.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-data-jpa@2.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "Pivotal Software, Inc.",
+      "group": "org.springframework.boot",
+      "name": "spring-boot-starter-aop",
+      "version": "2.2.2.RELEASE",
+      "description": "Starter for aspect-oriented programming with Spring AOP and AspectJ",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "64edfaee8235685c054af4cec9d21ac6"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f3c7529b69898084018e69e101ebc108237b1cce"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "77eeb26f21fa222eb8864ea9610d6f2656b9e0dcc6a358b598c32eac82ad9e49"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "2ce66ed43d09c60125bbd5a9bc0259f61d3141c88645aceea41c35ae08defbaaf9edf9266e223d5040570265ac6a8365eaa908d1e1073e541977e3482dcc156d"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "d95c430a65e29756e0201dc112717099e20e651ce75fd1a1ff52d46ea15c0db55ee028b5f20fcd2b74a575f0754e5702"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "c3f5d10e3a6d74e3fa3e8aa77e747933475bdadf1270bcb7f1887f241c6d8b4259323ec21465872f6d8741a86aafa0c0"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "7f404268df35bc7de28e9fd27640a3844566bedd4beb10eb1e46a321a3dd5f8f"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "38b1b35ac2fef0e56db9338e454fef1906479ae9c5f7738bfe01864d760b0cb19077aa73326542747f0eb1e393ef8e9c98ac3c2fef65ee41ebdf3239e7a6b4a3"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-aop@2.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-aop@2.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "Pivotal Software, Inc.",
+      "group": "org.springframework.boot",
+      "name": "spring-boot-starter-jdbc",
+      "version": "2.2.2.RELEASE",
+      "description": "Starter for using JDBC with the HikariCP connection pool",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "4a17ace639c508497c9290d8baf09b4f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "62cbc3b594bd82e035bdcd6f93250f4826d407b6"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "25013e2614feb8a2088f4b3723bfed3073e03a6eb0426517030a4046756fe841"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "a7581c38ac55463ee6b2b5f208a628cc2c6f9f2632c5c673f7863021e50ead18b89a641d7f09af5a8ac478af97d602eb93d10c88a7dfa939e73d72fd0c07930d"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "6dac4a392a365a9dd912882d8574d25bd6290045f83ac445030dbbcb2fb7e34686bca395e38f422c1503072f65080b8a"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "cfc53eedf698c4fdf8ec3477f7f48b1f51df319685315ee2e5f4d15352f4c7ebdb1cdbfc443dc7135f0f6544f55bc048"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "79cd574305843b24b09bf6a150160d7610ea26f53cc2a04ef740080b128604d0"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "b786409d9e32e2e4ad902b18fe108ff4e0021a7e15245c973f8195d381e425f47a5d353c0855a42a459f290aed40ac6d13de8ebd7929306d32d0f390cfaa9583"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-jdbc@2.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-jdbc@2.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "Zaxxer.com",
+      "group": "com.zaxxer",
+      "name": "HikariCP",
+      "version": "3.4.1",
+      "description": "Ultimate JDBC Connection Pool",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "930d5942faeb0d1e82173cb19aa85be6"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "842894380a73b72c2ecd9e483403e4d5ef7d8b76"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "b826cb4e9f22cfaf7d6494b74f14807f88fd51fae2926831bd31d3d3e37f05c9"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "3226d542e907e913f4c9c0ad87aa65c6e49160dd8bb21e1b6b574b6f5166036366468e4ef6ab516918410de904994d2dcdb8c946e74c917ff64173b92f56b2ad"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "8f5656b29448c4acab67a92c630d681de7b25a83d570ebdd45cd367b82d81a417be64b35d897f1d39aaa6b639a66f0aa"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "bc398082a312b2a5edb4074828c6f76e97fd82e1a831ab4d9ae29415d0ba434f2a8e54d30a4460a47758bcdfebda9c08"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "dcab0514966e0f31af8a093b3b02302d97af41ef921080e6d157f953c0501493"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "3675033e3bfc0b56007b84935c1b836a7445f99c4f08f2b78f16964b6750d18c721c8775ad3993e02e8a17e4ceeb7e037d58af6dd6b471bc51afde2884996f07"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.zaxxer/HikariCP@3.4.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.zaxxer/HikariCP@3.4.1?type=jar"
+    },
+    {
+      "publisher": "Spring IO",
+      "group": "org.springframework",
+      "name": "spring-jdbc",
+      "version": "5.2.2.RELEASE",
+      "description": "Spring JDBC",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f024c36172f57c935d3bd20ba426ae94"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6f0070f04c60f77d0048dc5521f8aafd5a86e87e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7d1ba1e064b02df897d25d71258e5df2766b256fc16f4788ff40b2729cd1a59a"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "d3038a4eb0bde6fd8daff5d71cb74d762c571e6942ade2e3303e026ab998db9397ffa1f726ba9d0db8efb13d4a31df88838f6e12ec5805f028f7b525e1e037a4"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "84a5914533ee84a253bb8ea4a281424575708c631a04fdc0ab85b53ef8c98b1df47b7f36926d93080d06fed5563d52e0"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "bc2945cb99219f9f25a8fcd38b81808c90375871af8822e4af1efe88750a790731157e947c7ae4a06c3403ee92e922cd"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "a0c6a12f7a78f942b3662fa424be2b14972cfc35057c42fdd0fac37a7b661ea1"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "c9a74be0f8aceb4d9baa84532182c44267968ef1ca30ac435255e58c7a6e79e7eb95be1bd7bf9affe30ada3b5f1a0ef9614fee4d0dc2dfb5860ffde81d627a9a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework/spring-jdbc@5.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework/spring-jdbc@5.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "jakarta.activation",
+      "name": "jakarta.activation-api",
+      "version": "1.2.1",
+      "description": "",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "9b647398add993324d3d9e5effa6005a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "562a587face36ec7eff2db7f2fc95425c6602bc1"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8b0a0f52fa8b05c5431921a063ed866efaa41dadf2e3a7ee3e1961f2b0d9645b"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "c60edc99f119b9e0df0cf527e2512f2b7ab9db0e17c54e83850695f80f652c981eaae90a296db671cf7ed88a044c150224e030df333feb30f346e8a31fb794c6"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "07422d64a103aacb8956c2067175f2cc257494d2cc8dbde29ddf8d93778a2d4b3903565b17173a0b5230b59d535bd474"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "fe6be5e1fb1c0ee5236b2866c1e5058c84043fb4dc3dd5ad8f04e61c01c019c96e92ffdf1de0eaf7e657b2c02c6d898e"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "880a91ff9e978ac9208c84babd820dc2ded42e601d8a17688eb30883b598dec0"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "91c0b8cb956bdb06e79738a9db624022887b3d83838b708dd3c654f231ab6f9b4a27be2556fd14683cd6158bf8534b96acd2481054e0c946d6e9f641cc5af55b"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.1?type=jar"
+    },
+    {
+      "publisher": "Eclipse Foundation",
+      "group": "jakarta.persistence",
+      "name": "jakarta.persistence-api",
+      "version": "2.2.3",
+      "description": "Eclipse Enterprise for Java (EE4J) is an open source initiative to create standard APIs, implementations of those APIs, and technology compatibility kits for Java runtimes that enable development, deployment, and management of server-side and cloud-native applications.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e0a655f398f8e68e0afebb0f71fba4e5"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8f6ea5daedc614f07a3654a455660145286f024e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0c2d73ab36ad24eeed6e0bea928e9d0ef771de8df689e23b7754d366dda27c53"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "1e07257b631ae3331a71d7cd9136152cddebbe786ba50c689bec618a9eb659be8e952fe0405db36332cb6c12c6c87c6d648e817c027ea8c6e0c660ce82f6f424"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "d68e1f600244d7a3628244e0265208ce08881f4ea33a3cd1f085886f7ce755cdd44bc6788ebda1baf8bc23b1f3c844dd"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "fb77e58872d4e3ef6475094ea96f1ce32a1a7c3617393fcab47c47cb84f6995315c5f805d518c69a0cea751ce980bf13"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "3619596135b169649ed16b75972c39614192d2a802291a7eb4c1814ef7dc9ff8"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "045c7f1ec7f9191cd2ff35fadf5c037aa596a288189185fd10d5fed89cd3661b6353945083f4c3943c87e343b61a556699f43f00a0e928c165e52d57fe514fa5"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "EPL-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:maven/jakarta.persistence/jakarta.persistence-api@2.2.3?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/jakarta.persistence/jakarta.persistence-api@2.2.3?type=jar"
+    },
+    {
+      "publisher": "EE4J Community",
+      "group": "jakarta.transaction",
+      "name": "jakarta.transaction-api",
+      "version": "1.3.3",
+      "description": "Jakarta Transactions",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "cc45726045cc9a0728f803f9db4c90c4"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c4179d48720a1e87202115fbed6089bdc4195405"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0b02a194dd04ee2e192dc9da9579e10955dd6e8ac707adfc91d92f119b0e67ab"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "764ade8ba807682dcd1ec7382c35275f3d8ab09a03d5b45c48e732501190e2738269080aaf28aa8dd656c11ee84bfb7dae6953dd2768f2acecd3a8cf0ca4961e"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "63adeb3c5eb24ad0147377436b6e3208d5e97c0e800e0e1e4cb3ba92699f1b06034c2ba00e3689aa8f909ee96c432db0"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "dd0a253f45dac003d40ebeed7f38b0850ff4b08941d55db5b3bbf4c936f94062d23799729ff718c54a565de2482bfd3d"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "d47afbaf1daba46c7aa107bf1b476857523738370309394958f96a2105686684"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "1b744b2d939a8d0a2bbd0be29c717af4a5e2374ca26fbb95a16df03aa55d2aa092e9314f20d5b080f02030ae1b70e4904ef0f8e1509680b9001153cdb7bc1934"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "EPL-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3?type=jar"
+    },
+    {
+      "publisher": "Hibernate.org",
+      "group": "org.hibernate",
+      "name": "hibernate-core",
+      "version": "5.4.9.Final",
+      "description": "Hibernate's core ORM functionality",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "aae1f70c553b800d560ce06400c0e445"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6a7efbbe889e9644b163f5cc03936b7e2b360293"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5cb2d776dbeceae0f349eeff14f6a4409d7b4d0caa3e2c81b26ce9f7865f1701"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "958fbf7430246d742a93d9749f5d06f23261c91c3d2b791a2192ecb4c0bc473b08df4523cfbb4aa5bfef0d9da592c262c79992f072648f34f8ffb9643c7171d7"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "41cb77ce84151e6453496a33d6409222c99f91d2637f68df9a194d3019437b8aea650272b444a104c5e3955095799525"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "d7c912ee9a3b91385c3e7c15970cecb88f0da42e23b59b22d0c61787a8c2ee49ddbcd767b9cce9007e591c525a4fe365"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "0a521ac925880bde69d51fea75f7d6ccfee3ab971abcb0506ae2580311cb5fad"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "66057d2850323b5f4339eb8d38b28f3c78f04dafd3c2364e3cbadbe647fd16f7adc241b193a6fc9022d3a9a18ba1a237d9402f4848c2630cc244641b0197a197"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1+",
+            "url": "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.hibernate/hibernate-core@5.4.9.Final?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.hibernate/hibernate-core@5.4.9.Final?type=jar"
+    },
+    {
+      "publisher": "JBoss by Red Hat",
+      "group": "org.jboss.logging",
+      "name": "jboss-logging",
+      "version": "3.4.1.Final",
+      "description": "The JBoss Logging Framework",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "52ee373b84e39570c78c0815006375bc"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "40fd4d696c55793e996d1ff3c475833f836c2498"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8efe877d93e5e1057a1388b2950503b88b0c28447364fde08adbec61e524eeb8"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "c17b8882481c0cb8fbcdf7ea33d268e2173b1bfe04be71e61d5f07c3040b1c33b58781063f8ebf27325979d02255e62d1df16a633ac22f9d08adeb5c6b83a32a"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "1a9a57638b6d9da1f50dc92da88405878885ccfc1cd6e3a66f5cee1fcef5af51a2d63294afd23f2300f550758af58469"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "aabecb31aaa548a5bf9ed6f540ad91e8f3c713a10c351c43aa71e845f6f80d81d673484e1c566ab246c80c8c77acfa74"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "447c31f632013a87e7e9e90a346b2011f2213df22a3844a502e813536f14611c"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "1b34af205a56d3f93d2070e335ef853090fb7dabe630b05beeee13c8596503c2f242fc93aa7a8763418771bc3593e65e8bd93c62288324e29caaf53ffbee27d0"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar"
+    },
+    {
+      "publisher": "Shigeru Chiba, www.javassist.org",
+      "group": "org.javassist",
+      "name": "javassist",
+      "version": "3.24.0-GA",
+      "description": "Javassist (JAVA programming ASSISTant) makes Java bytecode manipulation simple. It is a class library for editing bytecodes in Java.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "23fd22d0d089ddfac567a39ce0cb1a91"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d7466fc2e3af7c023e95c510f06448ad29b225b3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "aba81efa678b621203fb89aeff81d6f126f7a9dd709401e5609c42976684ae23"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "e57dad74a3edef837ece841d06e4a7c96ffecab8fbcba56fe5f7eccd662f0c0d757880a6073793a8c75ad7a0a1d146346b75cdbfe4fd8a271048a54446e5d1a2"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "4867afdb7522b3dbfa10a51264ac6c15a2a8083d16c8dbef318275d24687768f35130b1c17d8407ca8ecf855abd83dff"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "a52be891987d4fc7d319e6417e0cd9a28f189d8623b803d72b5429e118da73b9937899231825e793d37b434d7522d283"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "0cf8db7d2a5f7e1a70827538cb4b0b446fcc239f05ca55d9bf8f2a50f1e08af3"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "ed9675f9f070203801eb762092ac99636d376b7ef563f99508283006a65a0d2dfce38e1ba7ff2ccfebcede0376ba0724b76b459ca112477234aed8208807f785"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MPL-1.1"
+          }
+        },
+        {
+          "license": {
+            "id": "LGPL-2.1-only"
+          }
+        },
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.javassist/javassist@3.24.0-GA?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.javassist/javassist@3.24.0-GA?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "net.bytebuddy",
+      "name": "byte-buddy",
+      "version": "1.10.4",
+      "description": "Byte Buddy is a Java library for creating Java classes at run time. This artifact is a build of Byte Buddy with all ASM dependencies repackaged into its own name space.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "49f50b39ecf7b6d6b3932ccaee108ee2"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e682f5d73de28ac3577aaa71021d355f2ad560f7"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1bbad1cfb8100bf0f70a115653c7250dbf8d1df838058f21a651dd20d0bf4741"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "b07899d8c46f7927e5ffe0ba95204e7674b4a8bd58181ae23bc47b1cdb3fba9802ef56712d131a43c1e5dafc3d875c851b9aaf9cd23774113a1421a5a0a8a905"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "fd9b2431a65ec3b0270e910927a9a44f5d09575fc2d94bf80b78a0335c8c358f44387a2d9786c0782a160558c273346f"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "07531940761ea67c24bec365e745c88f9bc5e29cef84a78d32c9ab4906561c5adea4b81d467d2c4ba6f913eefffedf40"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "1666bdfe042a107bc2f6a5b709f182ced5199f4d3ddb7017e04d17da9d2d9211"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "0b46c1b58f9d641af328d584927556cf2300dab7cc51c03a4ec29da710c8feebc84e842568cb0c43ef86f1cb14cd28b36ed297c5fdf2b405dd4f7dba5ff8b178"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/net.bytebuddy/byte-buddy@1.10.4?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/net.bytebuddy/byte-buddy@1.10.4?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "antlr",
+      "name": "antlr",
+      "version": "2.7.7",
+      "description": "A framework for constructing recognizers, compilers, and translators from grammatical descriptions containing Java, C#, C++, or Python actions.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f8f1352c52a4c6a500b597596501fc64"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "83cd2cd674a217ade95a4bb83a8a14f351f48bd0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "88fbda4b912596b9f56e8e12e580cc954bacfb51776ecfddd3e18fc1cf56dc4c"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "311c3115f9f6651d1711c52d1739e25a70f25456cacb9a2cdde7627498c30b13d721133cc75b39462ad18812a82472ef1b3b9d64fab5abb0377c12bf82043a74"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "2e811e531ce30a2a905d093a00de596cf04406413b60422db8252b46125cadf07b71459cf6ac6da575ec030a9bf05e57"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "bdf019332ae8714ef6a3904bb42bb08c1fe4feacf5e6137274884b0377d4e5b5f7aa9fe8e1ef5ca9b3e15f12320fdb67"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "babce5c8beb1d5907a7ed6354589e991da7d8d5cbd86c479abfa1e1dfc4d2eb8"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "3a8ce565280a157dd6e08fb68c317a4c28616099c56bc4992c38cf74a10a54a89e18e7c45190ce8511360798a87adc92f432382f9d9bdde0d56664b50044b517"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:maven/antlr/antlr@2.7.7?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/antlr/antlr@2.7.7?type=jar"
+    },
+    {
+      "publisher": "JBoss by Red Hat",
+      "group": "org.jboss",
+      "name": "jandex",
+      "version": "2.1.1.Final",
+      "description": "Parent POM for JBoss projects. Provides default project build configuration.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "0f4d26aa9e426c8c4949eb91318a7987"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c89aa5564fea8b08b9b41f0bbcabb8fed0d89c0d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "fbc29e662aaf8741c1c0bdb1c725f120bb4b3a37644957e5ea83ba516029893c"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "709ba3cd4e90bd56b9fab4b1dd334476cf9047eaa099f0bd3f315d352fb00dcd90bfaa1f37d774b1461c2a6cf6b69775cee10e68c73108e3a78e18f52a2de199"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "f72b784d0bb775b890e9164236d093f460c651165232565044ca3c5580d529d338d8bb478c53ea79b08e88ce0ca9f008"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "7105efed945d162e736d1393ce015aa959596d194b2ea316bf65f0c00f7f56735941f02ce7a7c2743407c0b472bcec3d"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "72e947b271315eda629d16217babad56269532853a93e16e175ce2db871ec37a"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "b2ab5e417fda2174a968a944afe8fe04d239ee844e0536602929ff409e825ebb2cc9b501af8e18046392fd3b514a788c17fb60b5dbb97506ac00d91dcb38f33b"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.jboss/jandex@2.1.1.Final?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.jboss/jandex@2.1.1.Final?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.dom4j",
+      "name": "dom4j",
+      "version": "2.1.1",
+      "description": "flexible XML framework for Java",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f5710c1d5f5627ae5ce850a0b12ea87a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "3dce5dbb3571aa820c677fadd8349bfa8f00c199"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "a2ef5fb4990b914a31176c51f6137f6f04253dd165420985051f9fd4fb032128"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "547da0752ffb12ce40800449376f2f7e20f053f816de4ae8adf1a4fad5a3b87ce4e98e95650671a6c9cdcbbf7c20a4b61e711e5ae8d324c923d508bcb07e02e1"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "dcc5d1574e166c14aaa2b582bcb53d0b1310e0bc6cca481a727c4b62784c92416abf25b1665534d58f39d9e52711ad5d"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "d64fa541bf438398870048660b67abad21579355a168c9c03e5cd941eb0992510c8775664933cebbf8d7e59f7131080b"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "e0d00e2f06b89df74355383e657d0b7b2a67b4fe3b5de58967eaa27fa0efad90"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "00e4ce0afa1bff9f0abd1d9fd07d76157f26347b4d6931314f6f082c528bb5e60c32eb9bb16c23f5adc5ee5dcb902135fed2a4a5cb3995afb143f1fe1f938959"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.dom4j/dom4j@2.1.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.dom4j/dom4j@2.1.1?type=jar"
+    },
+    {
+      "publisher": "Hibernate.org",
+      "group": "org.hibernate.common",
+      "name": "hibernate-commons-annotations",
+      "version": "5.1.0.Final",
+      "description": "Common reflection code used in support of annotation processing",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "a617d0538d80949185648c9c790e60ad"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "700aeedc4a2089816621948f0379e17cbd17d5db"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1e3bfcfe9efdb40e9d3c084c9bcf8597e492e30294c7e40b56ed18a67c2838cd"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "12a3c896d8cb0fc9faa3499a3adb964b525737284476661dd1449f940e0232049606d825ad0cb73f895926db198184916f0756b70373922af07734de7f1671ae"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "3ca65a6df68cc544ce999a501c6a146a223ecc05b98f72bfc9602321e4847d1cd674b4479a1268be5867d35b94897ecf"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "3e20003f53e46c6a61ac39318cfd8ba95aaf5722d65743ba616b22bcbdc4435f2ef82381dc88e13fc0ac88fc490c1b5e"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "ee77f72ab3c41fcefafac4ab08e6e08b8cc203c7194aad54d777d3deeb24e8b2"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "290adad03e3b19cecfb77fec064a36d6bb25685c1f2cc5683c42a2ee99e001be4ee3baa23e25955d922bfc9b884da181381256654b72136b48b6cc37dff036a2"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1+",
+            "url": "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.hibernate.common/hibernate-commons-annotations@5.1.0.Final?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.hibernate.common/hibernate-commons-annotations@5.1.0.Final?type=jar"
+    },
+    {
+      "publisher": "Oracle Corporation",
+      "group": "org.glassfish.jaxb",
+      "name": "jaxb-runtime",
+      "version": "2.3.2",
+      "description": "JAXB (JSR 222) Reference Implementation",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "9c3bf13a58e56c1b955bf5a365ca10b2"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5528bc882ea499a09d720b42af11785c4fc6be2a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e6e0a1e89fb6ff786279e6a0082d5cef52dc2ebe67053d041800737652b4fd1b"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "8a6cf3dd9fac4fb6ddb5f0861a2cac093e04d186fc787ee78c30862d225eb677b9605e1177cf57da0d4f45c613f107187c330be0684b43b0cab9a922cd96db66"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "6a28d20f1ff24c17285c8e5cdf9c17cbfccae0e96154e635d1a6c4c590b974272cd509f6d17e3aa0a581934746c9f1af"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "f19e05f4bf99a9af602ae6d72a1290ba45ec1030bfef86d00707911ad6030b3788162dbe595c4379a8ff19be7264aad6"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "d2c4e6d5c942734e22904d40737beb2008c1403a44b8c1709e88e5cc5c77b2e8"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "5d12e1468235d641cf7ed0bb4d09f6c5efeb6787a380be1e0d63b1aa605e4e963e67699709e831503c5d0398ebc982a635ab96216a8671bd654afc355a5c3fec"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.2?type=jar"
+    },
+    {
+      "publisher": "Oracle Corporation",
+      "group": "org.glassfish.jaxb",
+      "name": "txw2",
+      "version": "2.3.2",
+      "description": "TXW is a library that allows you to write XML documents.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "3f278f148c5d27dc608c25cb7d093b94"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ce5be7da2e442c25ec14c766cb60cb802741727b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4a6a9f483388d461b81aa9a28c685b8b74c0597993bf1884b04eddbca95f48fe"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "66c174093c47b75b900159c5449bd99eb15308d15b395771367adc5862612edb985c3678428c4f60e7c27b46d123afac39277f80db766511a6b6f0756d525559"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "e7793fe9931d56761fa123b087de6266d4b5dc42aba30196039e578600d5dd32f0f42c5874e3021e6e0f6e60dbe5e876"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "c9f72239a29ca1cdca3273e34ad2504eb08c1d6b52f194b5254699a735d972b4d969936b92bfeeec63812a210f12c95f"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "83200ac789b8754066fd87efb964845ff90b155fed4a456df21968be63d72bfd"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "c25db123091f280eceb180b1b7801dd0704ed388e77fd4d6a2fb423e9870b3eda89070c008ecf03c4ec43fd8be65158e9a24c013ef226f151c171978d26af0a5"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.glassfish.jaxb/txw2@2.3.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.glassfish.jaxb/txw2@2.3.2?type=jar"
+    },
+    {
+      "publisher": "Eclipse Foundation",
+      "group": "com.sun.istack",
+      "name": "istack-commons-runtime",
+      "version": "3.0.8",
+      "description": "istack common utility code",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d8555a2f242c55d6727b4d0e82ab8446"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d6a97364045aa6b99bf2d3c566a3f98599c2d296"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4ffabb06be454a05e4398e20c77fa2b6308d4b88dfbef7ca30a76b5b7d5505ef"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "e712166f961cca819a61bd6efc93b93759788d283af73dcc6ed09c0f9c045d7dc2f7fabc0e236b2996fcdebe26e1b2ec5ea45eb4353943dad82ecfef0488305e"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "69d93d701501c6d63b67812f807d14f9625e309239153d9bdc0b646874c522a2c2837b39a55805bc1aa145a0ebb5cd1b"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "b994ebc952b4aa29e647f45d42884cfa60889d224200d4e8d213be77a78c8b9d91fe120b32b200c1f31228538c0aad0e"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "403bd292046f9755fa5dc0de1da2990142b8614e508932465e7b041f517412af"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "2fbcff4cae2c823da7dd35f6b1789283466e2b7d7de5bbf1fca95883dbb7ea99148b98862192adb17ab0c96029ea18f5cc0daae6aa0facc0f57c9f8dfbaeda51"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.8?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.8?type=jar"
+    },
+    {
+      "publisher": "Eclipse Foundation",
+      "group": "org.jvnet.staxex",
+      "name": "stax-ex",
+      "version": "1.8.1",
+      "description": "Extensions to JSR-173 StAX API.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "8fea4418fa80e957e39c174cec08053c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "78011e483a21102fb4858f3e8f269a677e50aa23"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "20522549056e9e50aa35ef0b445a2e47a53d06be0b0a9467d704e2483ffb049a"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "d060ea5dcc81508a1078bd0ed947553a5652a5a78da76cd00dc2e384dca014166dfe92777fceb7d7868699894d7e40ecef99fac7771372025bfd7f1fa3e2fe32"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "0e6637e7ccbe3a62b29a4f048aea98ec67a72ddb3ff3fb4957fc4977009387ade09926f00ad8da9528cc1a2b10de23a6"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "f199dbecf21b47be92e1ee7bea80e80a35c9913f5661564ad653715f3c6038c1c7c4f9ed550c441e01c427a075956bb0"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "820545107971844e250a18c5e6e7eae79e79ff14948dd1e7b1de06fc1c5f6446"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "2dd081617cce475e96e00e302d8093bc38367a8d469c8a3bcbc630947163ffe365148537ce0a85a52ca2bdd9ab43a925dc508ee1a09d1fb10c8c0697d2654ffb"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.jvnet.staxex/stax-ex@1.8.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.jvnet.staxex/stax-ex@1.8.1?type=jar"
+    },
+    {
+      "publisher": "Eclipse Foundation",
+      "group": "com.sun.xml.fastinfoset",
+      "name": "FastInfoset",
+      "version": "1.2.16",
+      "description": "Open Source implementation of the Fast Infoset Standard for Binary XML (http://www.itu.int/ITU-T/asn1/).",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f7f4be4695e2501a6d585beca305c74c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "4eb6a0adad553bf759ffe86927df6f3b848c8bea"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "056f3a1e144409f21ed16afc26805f58e9a21f3fce1543c42d400719d250c511"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "cd57377d61d66ac2ab6ab90483252385fe2bbb9e13dee07913362a64ffe97b16082df981dbe469df3f67ad946827be6f4355d63003a393bda62a0fc8b54a590b"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "0a8d6e803d9ec1dc73eb09dd7eaba0b045ae02985e37c7e9a5fcc5e973a6d4ac9f868b5cdf6dcd8b4011950764d338ef"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "82f7d05ca6a2273a78a376590259fa1993bfdab6d4fc4c2696d488e9cd6ec283f6293b5bd0dc90c099bc463af1b39c34"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "76c640acf962796dfa246ec63fc4dcf3c7cc4e43dbc687b6ceefeae48c3246a6"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "4c3937fa15b1a7943497837eb0471c7e394ed7f938b4c0db40e12634e6868221fbdf547cd2a9470896309ddd93f15e40ff4646e71954a37c6ee5b817e304efb1"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.sun.xml.fastinfoset/FastInfoset@1.2.16?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.sun.xml.fastinfoset/FastInfoset@1.2.16?type=jar"
+    },
+    {
+      "publisher": "Pivotal Software, Inc.",
+      "group": "org.springframework.data",
+      "name": "spring-data-jpa",
+      "version": "2.2.3.RELEASE",
+      "description": "Spring Data module for JPA repositories.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6b71e518eaa02c2271c54bf789084518"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9ddf7702fdc9c15e266bd2d20deeb20b6680d7d4"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2d852cc194d9453c5aa7f79cc1bc6e0e702a5776acee4757ee983c8a374b0b15"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "153c1a331e2a1ffe572dc4e33e01ceadbbc2d9fc580b003f0abea56ff72ec8612a0bf389095afa37d5a26eac463e11fcd51dd264e25877c602333c1983d97399"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "5dd926cb570589f97a213c9fa570a506e8c7be204fad03cc255e9661d9284eba02f09d3ca7572dbad0fa5b852d287dcc"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "6c166418ad81e49a45d758ad2873c9cd8e4cca15aa21f8f0e1c8887664bf795d595eafc75b22dd39fa1c7c65976d27ca"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "5a034ab98749db80aca7725d912a57a5772af24f00bf20ac18ed139b814b6c6c"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "329edb9acdb4a3cf7568ab8548cd12ec62855fa85d30a569b927178154fa6fd31e45c8bdcd97bf70db3e8a4b11d85d0b761c4a315c11f10733a97d29d43522c3"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.data/spring-data-jpa@2.2.3.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.data/spring-data-jpa@2.2.3.RELEASE?type=jar"
+    },
+    {
+      "publisher": "Pivotal Software, Inc.",
+      "group": "org.springframework.data",
+      "name": "spring-data-commons",
+      "version": "2.2.3.RELEASE",
+      "description": "Global parent pom.xml to be used by Spring Data modules",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ce0ee56b81416a0a14fcb9727e0b7a3d"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "574349bf76bb4a85033e526efa0315ca9933fa83"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "6fc095f3433109ff79e48628ac91db0054a4909436b0230c007fb2da0034a84b"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "bc5fc43ba838301f7ae317f40106b994f523275df0a41e7938e2eeb5f9642bf2205d704c368a48c79c4b4117ff6cff556f3ea7f7cfc0f7a05ff270bf4b982c24"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "97757b0a75b99a9e64c0b87969a6b75dd8132d813d5e2e4eca950b43975f0659eee0584750b1603fb2d752b6365ca8a6"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "62aa80651aaed41185688e8805ed510fc21b2f6e6fd8a6222797e4600eb40eca33912c10b774ec94d3c43cfd1eea15cc"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "f893408fc7b30c3c9752731f923589d1e50028eaa030284339cb3100ba1cff3a"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "95f24edd69f5b5db9de3b1ea83cbd8924ff2ffc17572917d5db820361551afeb646f03009e8d7a90ef33dd3c5a60a26a890b5c486f579745b76dc144db7e667d"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.data/spring-data-commons@2.2.3.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.data/spring-data-commons@2.2.3.RELEASE?type=jar"
+    },
+    {
+      "publisher": "Spring IO",
+      "group": "org.springframework",
+      "name": "spring-tx",
+      "version": "5.2.2.RELEASE",
+      "description": "Spring Transaction",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "291345def43a9414dbc714dfded9a137"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "2af860baa0b094e13786613e15e1804edb7a5977"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "dcbde9808b6bff2ea1ab3fa33eb12ba5d03db54ba16810206dd41d0ad6ec0dff"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "5550a8df8c1f7383c93744f6dbd5a4f5acb31ea33a00fc8d102238699280802c16549cc1a600e454fb756fecbeb2f8e4b8ceae636e93419e28498ed9642c3f43"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "8a282792c1fba6db5b1a623165761cd4af4950ff367657cf419603c0aea2c5785ca9713ab19c0502cd2c9e1279ead951"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "d9aca6bb6e7be8a767115372ac1af404f65c26b4660d2ece73c02b2c75822b3d6212f50a2307c4478369ff78a2970aaa"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "6bfbecbb5d7ad9ad9b5ad7d8b346af6c038885e487da729b94eccbf5c82d3c4d"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "9ca5c50b50acbc70736e3feefdf989e9cd77a92448321f55a63d9c7f69135b2127786ff46bbed4ce118899f0ae6bd2e95585d93668661a034062207017920bd0"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework/spring-tx@5.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework/spring-tx@5.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "Spring IO",
+      "group": "org.springframework",
+      "name": "spring-beans",
+      "version": "5.2.2.RELEASE",
+      "description": "Spring Beans",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "a9d90d08943a10cb063ca121b228b3c4"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "81e4d9cc2e8fac88ab4eb7325c4521bd07c6389c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "58f16fa6718d9e2a456036b681b68dc38802c0da6c90feaf1e63a160b3b74cac"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "6b7df05d61ab3334c50ea983aecd3756b9b26c88cb820b320bf30046bc1fb681769b9bd18cf1c8582c758bd24942c91b80719c94aa29266a0e3578cb252fc041"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "5ca62d6cdaabfa6eec94d1046a3fb5f0809041a47503e2cba714c934975384f35711ea763fb1889284deadd77bc5d3af"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "d861dcb13537b5e55482c870932346d1640e4fc137de018743b5a9010522e3236f234b8b9615ee3ca674ee45668a04fa"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "dea8b519e3b324ef626292c9e9905ef6c4effdce4761f59856f83a42bc3918dc"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "cbc8ea6e1f9aad4197412a85602250e20290799173421b53301aa7870974571c57c4f55b52118f7a47194ce60ebb81624a871435acc68c2b390d9ea837591163"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework/spring-beans@5.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework/spring-beans@5.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "Pivotal Software, Inc.",
+      "group": "org.springframework.boot",
+      "name": "spring-boot-starter-web",
+      "version": "2.2.5.RELEASE",
+      "description": "Starter for building web, including RESTful, applications using Spring MVC. Uses Tomcat as the default embedded container",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f39fc8c17eef620f3d035eddc56706f5"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c84df617eb302ea502af8b37406df13f1fe6669b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "a54c6a4349e8b2f12e644a64ac9f727d6342e70c83012daa77ca09a433428bc9"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "248725b27047a179b14e2fa2050e0c6bb1a87cb78b06286790d3201951f569e30cac3e6eae03a723d638366499676748c11fc96c2fc17dd4edca3f511914af52"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "596fdac200daa9fe3116bf80ea813147baaae9a1238cc1283695e8ae216f55749f07a707825af30a1dd0b8084ec19fd2"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "4107319f0c432e805c64679535e9628d2601d62a868b7f481e3c839829aa97a3d78c8e6076101448fa501a7c65a3dc92"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "fb6c5d9c20dbe95f6aa5afcd52ca004e8473470ad2398722bfcf3d033c703fae"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "735b35c5699b22f6658c9847b6726491aabb24bca24223a12f7680785313335619c8d831095e30ec0b15de65ae909fa8b5db2da576ed9a4d9b63e807146b833a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.2.5.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.2.5.RELEASE?type=jar"
+    },
+    {
+      "publisher": "Pivotal Software, Inc.",
+      "group": "org.springframework.boot",
+      "name": "spring-boot-starter-json",
+      "version": "2.2.2.RELEASE",
+      "description": "Starter for reading and writing json",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "38ea724b60ed821b3de68250063b70cc"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "7ef93e43938abf3064cce9b7317bdb8278060437"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bd393d66fe5fa969e2cc39e8f62539ab73dd6e06f1b5bec79d7f5dfd2ef260b2"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "ad2cb4f903788c3bd4d203bd6282d5989c3c8a71b2b5ff9f24be745e912a4448c2f355b32715519ded1235f49913edc0063d766c0902bab99da310738932131c"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "c7a6fce4384322dd8cf7e33dadef13cc0c369ed7305fa4155a20c7164ea1b7348b2c5b483b1fc0888f99767a6cca85ca"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "77d706ab24ebd3fefe33d3f0e3f374f4edd5fbe90e4ae978048e5d499daa0be6eda0dd63a0afb4762f9dfe1a95290d2e"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "0bf6a13d55e4cbc56ee0ee0e473cd3151837aa1010ac8746a28d2c1306f94815"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "b47da7619f9850901585ebae0501e993952632cb85972d199c9c700c6cf728e337c1b9ecaaffab15720c0b5bff88ae67dd50c7fffadb7122422964d4ed150534"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "FasterXML",
+      "group": "com.fasterxml.jackson.datatype",
+      "name": "jackson-datatype-jdk8",
+      "version": "2.10.1",
+      "description": "Add-on module for Jackson (http://jackson.codehaus.org) to support JDK 8 data types.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "5ed821ec4bb9f16056a74c228f5a0788"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "db9247b3eb6f07520ff6ff6d1070439edd6803c3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "05c45b1441e74ea5e4b0c7a20823d2c7cfded946108902b5691a129e78f60515"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "505dd1722e3ce911f37f635401dcf358a5de5da7952dde78e4ded416bc13a76fb9f4763dd2665a77c2b468cdcb0ef8f120917eb0732c473cb1293dd3f3f9a4dd"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "40312b0a1179a02a81f2b52dc5cbb21dc0aa99c9cdea33cf4e4e0e62283b9d61a8c3bdbc61c04e1347cdc27aa093fb9a"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "79b42ff902c56bd2f8246d9c26e659b028e9f294147db81a2435c0100ccbcb36279763bcbb52729461584563f1352dd4"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "311f0b7a9ec5f819672f4f454f429a417c4c8272046c9bd589f84ad2fd0c4e81"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "cb904456062a0036ded14572c37d42cff778d8d641dfe9566be623774e01a6c99733fb2de63e8ac057a3ee10027c90547a3f981c024e2b9ffea3544a7002f615"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.10.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.10.1?type=jar"
+    },
+    {
+      "publisher": "FasterXML",
+      "group": "com.fasterxml.jackson.datatype",
+      "name": "jackson-datatype-jsr310",
+      "version": "2.10.1",
+      "description": "Add-on module to support JSR-310 (Java 8 Date & Time API) data types.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f84efaf51bbfc3c8a783168dcb24c99a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "52ee272b0181a1c0df5c931235c494b1e0e022d0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5e7d0363068e3d42ac7f6234c88ade8867174009866e6f00f496edb5b295b56f"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "fe7136a29e57a1663007aea7dc0ded4b1d7d3714dd94c30a7763008e025bea143064320371acdd6f16027bbb7c4a7658f8d4609102748fa3caf1640721628347"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "6feb1dadef178652aea44e4c0f2f444f07149e8f6413692a70e8a70720017520af04e1a907dce0f0073ed1faa46e9ca9"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "33dba309b28a88a0e15b5ba538cd854ac6313f87a3920e2082929e8cb7cf5d67328a5b4bee5fc98010fa3dd97d046d82"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "deb2c0f89f45e2b627794df2539b92d51a626b80de2c06c34ff01602155898f6"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "1777853ec049be220e374c9b5ac943ad3293576ba13542d4ad9448d45ebf4dc21c34dc618036c2ce783ac07fa7fcb77e0e0dfe938b8920214cf103be64b0ecc1"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.10.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.10.1?type=jar"
+    },
+    {
+      "publisher": "FasterXML",
+      "group": "com.fasterxml.jackson.module",
+      "name": "jackson-module-parameter-names",
+      "version": "2.10.1",
+      "description": "Add-on module for Jackson (http://jackson.codehaus.org) to support introspection of method/constructor parameter names, without having to add explicit property name annotation.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "423bbff0e614dd71733ac716416cf4d8"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6643b48d7dab2fb8c874526bea13ce4cd1a76cb9"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e8083b8aef3704fd8a1032454d1d80ad5e250a678fbb3bc8ac89c0f0567badf3"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "72d8222b136604bce4d57e7015db88db12b875ce1ed3d7da38f4ac3a848ac8d3dba1e7daabcf2e13f974acc964ab0de7e3491e978d038c0e1c46ee8c1e59df6b"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "a5f6617fef1f58232864fe14a2dbd30c598f60b3caa17b895488588d0a36d7e2ebedf7a565363556d72ae3208688a7a5"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "db6c0ab0df894e5f9ecafb9a956f52df45488935e6b591f7179d0ba9d0401ff0fe2052e3e439b879db39fc166a9200ce"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "a05855b0e3603b93ced12c653e999cb2751179cce3bc4ae7eaae856d5df8feb9"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "aae71567d520e208ef95abdc9b4f7bc8e611c91339486078600f4d2e26759692515deb1134d021d7fcff7706e7890c2f5f61d2763ac41b35c57f7a71a9551128"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.10.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.10.1?type=jar"
+    },
+    {
+      "publisher": "Pivotal Software, Inc.",
+      "group": "org.springframework.boot",
+      "name": "spring-boot-starter-tomcat",
+      "version": "2.2.2.RELEASE",
+      "description": "Starter for using Tomcat as the embedded servlet container. Default servlet container starter used by spring-boot-starter-web",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d30abc7e924870caef0262b07ac62228"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "cd343e40e4de11f78d6d70f3f35f4ca93ea9de9f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "6d87066a8dae2a8d48efd7a781843bb0e53ac010ff113bbdfaac2df9d771a086"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "06a9decfca651aa825f8218ba73d0dca9a638e10d1f7a1e2c79384ab6898f7b038fa6ab180f1c3d702ed3eb004ac1dc089a55a2f01fcc14d2d01e067b9250c8a"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "c96dbd5d7ca1163caa615b5a80242a6766dc1244a38400e31f2e13f92f4db96e32cdc4a24f10d90126ebbe0589d081c7"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "3e798abcb0ebc404d499b632e2d21701a510879e21feb2fc0948aad4b21e40d2b744a5bcb1ffb400f0de14be19997fa4"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "6bb758d69136b2d60e16a5b5826f90545bdd7599af07cd6aa892d9806af91843"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "020e8accc1495f1dd7bc2dac88a0c9ab1eebfc8d99305546451fcc2115196464f59772826b43a4dcaad1b551c0df33c3f12efbc7047ba29c6c0495801cc4e5c4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.apache.tomcat.embed",
+      "name": "tomcat-embed-core",
+      "version": "9.0.29",
+      "description": "Core Tomcat implementation",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "44be753971eba479c2b05683f570c1d2"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "207dc9ca4215853d96ed695862f9873001f02a4b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "eacbae5a6436e47fdcbd4e961df20bdc53a50e325ff8739b412578c0429d70ee"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "415f0430862d26e38c2ef0f26d87db0e7cdd0c55d9b5a6e64f8d97ede4c8001cbfffdb9955e0bf04ae3f58b065dcd4e995f82e059f17d1a896416e1d2e62a61c"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "3f538b86aded622647ccca1f09aea6855a059fb17044925c410a4ccb7a18761b04fc10946e0512a39d779cdae93b3101"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "39d15c3521504a2515e08f8bffcdba9ef85c5c715c646a507a109851cefe45411290c18f1a1b2ff01915c0d38f71fc7a"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "2b7bebaed4cd03663b02afc215cdddbd464318ded5f09475dd275a60e7199018"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "f26a37899214c64525a207fa47a2283eebf71918f8eea1b8aa3c47737e1bc5e2f4121ba0e5dd8ec05109895e50eea51edfc1083a9555814521580cd82146ae97"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.29?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.29?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.apache.tomcat.embed",
+      "name": "tomcat-embed-el",
+      "version": "9.0.29",
+      "description": "Core Tomcat implementation",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1d8c3ae258beaf968a6611709bfff2d8"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "3c1186083cb613c18949ffac21d856ecf8cdfd13"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4957e123d0521c624315c3bf3b2385b9dc1e704eb46b65a3c01e58f3d40cf262"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "429b3524885f7a5af7a583252a253cc6faabaa51810a48548df6bafba8d9e7b4af1268441da0804fd9615656b02e9534bd8cb3d8309065ddcf9c22dc6cac6d43"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "896a0115c948424f2020891d77c1525408425e3e693d8be9ed9cad9b36e5aeda40f9ef958440098bd4cd8e984933799f"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "52c532cc50b4cb75114ba59cb03048c597f17367a825186650266fdd31e76dbc653a2847a72b40390bd3af4b838d0592"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "69148eed625cba84cc76b76d1a2668295f0a52c3d8b778f4912789b9d13c2e12"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "e6f46abea61a21393ea5ddda5196bdd4910901e3470df2065b07fd297ca328146f9013bd730c0e34d214dd6c320f94cf17e754a1b65f90da98f46d15d029ae2b"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.29?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.29?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.apache.tomcat.embed",
+      "name": "tomcat-embed-websocket",
+      "version": "9.0.29",
+      "description": "Core Tomcat implementation",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "08da7687d4b7a04162cce01f9c0cef42"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "57a550a531648dd665444f11d45c352a6978c7b6"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e7b5626f690706c4bc38886407d0d0eb0626a95245ba6f397b3868ca194e8525"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "4c20c9692194c56d779a73b46955ae8997a96817fb21e65f6cd5cbb4fde273a9d1cbd86cefe755b2b6285fbadbcf3bab943120f59c3627964375d041995fc6d6"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "9e04d0e990beecfe764ff7ac615d4a9c8025cd5949dfe1322c307953e929e37f0aae61e38aaf79d6064c784e038ef3a4"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "6c97820779a6a060cef92d46ca963cb1befb29d365a230cc1778dad7cb401e69fe67307ee5ca9d8c63108a909f930460"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "35ba85bc779bd895c3162c961ef1ecaebeb9dcdb61d8a59264522024582beb9b"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "1b36aa008974928f7b7bf90b76817548b651223a5085d24b43e2b51b4bc4eea0e11b414b0b817ad348f78bd15d62d9818020d7ae6d38d05edd8e01491edbe639"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.29?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.29?type=jar"
+    },
+    {
+      "publisher": "Pivotal Software, Inc.",
+      "group": "org.springframework.boot",
+      "name": "spring-boot-starter-validation",
+      "version": "2.2.2.RELEASE",
+      "description": "Starter for using Java Bean Validation with Hibernate Validator",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "29007604e0e73f74ecc893a69479c5ea"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ef3ac3571ae518f22117e8bce826970b358f3cdf"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "cfaabe379dccb0ff3c1bd97a7046f956e6b65573c7a809295d5716a4863aa9d9"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "686ac296663e35200fdceec3d18060fe7b0348041d5708e46647057813ca99c61007423b4da2247c2cef03b44b8823b53de1dd958023db1e256e3de93d18aa59"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "af203a133c7b6806002626f713bf4543fb93f81b0fb58718ee7a66f96bfe9a41b5accff143c732ffddf77bf65acf241c"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "501d2f5ae9a70d39c6a2701c38c900364674ae256cf62aead5ad7e435bd4f650c313b0d653e028975b0739bbaa1bbbc5"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "15b34f01a4112e4a65f65b81bae48ce8e00171e0ee35544ff3af875c0f383f0e"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "dc454f607dde976018e5fabfcbebab917582a472f6e06b91fb3fcea06d1e8d1cefdcd0143b82529f3a1b17af763f2259d716824891c59c8647451603ac36e453"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-validation@2.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-validation@2.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "jakarta.validation",
+      "name": "jakarta.validation-api",
+      "version": "2.0.1",
+      "description": "Bean Validation API",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "14e2c4707c5a54d143f99406a7c385d0"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5a864a58587cd76243b8ec55dd7115c9eac25c08"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "cbd4097d66194f4793c59d8d145915313717caebb8bd3590ae6f716eadc8d351"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "4400f1372ba0f5d878a7a2b9087c4fea3ea387d8035a0580c82605232a9dd47651250a211c88d480d7a8dc7bfdb681c4a11f8a738453a27848965c5ea5d53525"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "35d0863f0ef6dcc28b94f8f5aa5d99e5f655220649653b16a199331877da1066e78c1e79aff7d5f8345b4373daae99f9"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "963cc105e1cba2861d324b777cc77342abf4a2821e34db0ef3725fdb7c29e71cb1a31e896fb99c4fe96ff03b646452e2"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "0da3525b580f39c2041a10e10bbfbe739c370f5153c920751c37c78e093e1b2e"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "290d50272b7ac531eb4b0abfee3660d085fabca2a4bf9177706625c3d2731300e6b256a666dd20f164786430f0ca76b59e32ea8b4149709b21076620ef3b13c3"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.1?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.hibernate.validator",
+      "name": "hibernate-validator",
+      "version": "6.0.18.Final",
+      "description": "Hibernate's Bean Validation (JSR-380) reference implementation.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d3eeb4f1bf013d939b86dfc34b0c6a5d"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "7fd00bcd87e14b6ba66279282ef15efa30dd2492"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "79fb11445bc48e1ea6fb259e825d58b3c9a5fa2b7e3c9527e41e4aeda82de907"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "5b4ffeb132b5920eb35beb3a8f82c18499421220553b172de5755cecff7403cca7544381cf63611a4b8043eee0d50cc2ac711b34d11d2ac71d43a9c42bb60d84"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "029c165d06e91aab9de69977e36d70b8d60b6fda7fcf0e0a9177806924b1e9bb3e77f54ef93e822ebe596abda37dbd9f"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "a4a6230498cb0fb02fdc80723d04f17b696e9ac546e84efd86aa12627c32199d7b73cc963948b5a6bcd95f81bc3d4e86"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "1a6aed3bafecccc0290dd497ba54228977f1532f19b9d51d13e3d6e7b234ce0e"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "07ac81583a1d7832fd7e4e0ebb5c9234a85a6bc5f2f54316a7e67e9c8ca111c947c025d12c456f8f171a234e3881bf888873f9f7291c39e81c88f105b48f4722"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.hibernate.validator/hibernate-validator@6.0.18.Final?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.hibernate.validator/hibernate-validator@6.0.18.Final?type=jar"
+    },
+    {
+      "publisher": "Spring IO",
+      "group": "org.springframework",
+      "name": "spring-web",
+      "version": "5.2.2.RELEASE",
+      "description": "Spring Web",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "8c1caecd2cd2a8e8c116f44d862e1daa"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d9b0a8079b7d604f134e3054127a7aeba65949a5"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "b99203146edecf0c28d0c930f91526e1237cd4048ad5022cabaeab5ac4e4bb83"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "fac3d8e3c12f85545e8be7e776afe0c23c0cf418d825e2de57f975c5584c953762699b30cc5a4f6a1fe36b4a593cc1539984b06fa1b9a47d01e04e022f7d0bdf"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "62ea3a640a2cb6c17c04e380f90eb1209a232970a3103f83d0bcb40ee368b5f7cbfc0eb6400233de32662c188c6e303d"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "84c9d4387a94b219e77e8dd3c2fce60fa67cde906c7f20b261bf007e21d3918b28b4f0da171f3fb5418de25cc3bbff6d"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "d2dc421a6557e50a7fb055ed094731a5996d2a0b7cde501c9777e866ec258a58"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "6cd4ba8fbf3fd5df49e708400b5bc2bfb24587aa17d1d00857b674b42623ee93a57b70bda14f581a8671de85acc7be944e2a4e754495f1283d1b8601168b9664"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework/spring-web@5.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework/spring-web@5.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "Spring IO",
+      "group": "org.springframework",
+      "name": "spring-webmvc",
+      "version": "5.2.2.RELEASE",
+      "description": "Spring Web MVC",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ac88114f687d16d181769ad5d1a49ff0"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a0e9e88a296c09850f92318872f4dee9f62c8c13"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e3da078986c603697551349f84c062c0322d7a564a2f4cddf8fcf324ebbd6a08"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "797b93a47d000082c40f3e83cbc9da582ef5fc94e9f5f1875cf1423975a93d74aa342aa71f9fab72bda1a0726bd86e47c041361a68d75df6aba57492515c3f88"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "d38b573c23703b02d60fff66a72efa50e0a723c010946ac720366f3747e3e252761e7a04c0ccd70cb4f795eacdc08514"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "ab7f2da979f85ba1a9e190c2105da8c43b5aa470e22f3a1fd214688b6d920a15b9baa30558baad96e9e1f354d38db7fb"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "4c8c2d0e357a837917e712f25d7410cc40757c6621211a9e1e0475da6d2e7ca4"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "1c29929921db133056708f6368a1c1484a9ee4e3642bb1abcfed87edac9e6a715c0297eadd64989e00959b3273975c9dae39f0d8a4daefc555a5ffb52b112004"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework/spring-webmvc@5.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework/spring-webmvc@5.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "Spring IO",
+      "group": "org.springframework",
+      "name": "spring-expression",
+      "version": "5.2.2.RELEASE",
+      "description": "Spring Expression Language (SpEL)",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2beb78ccde56444dd683d7ddeb23a949"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "eb93bc4d4eb8e0bee60ea910e0fd615869336643"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8e7c7de72ca95ee5c4adeb5d07f37f20e5607e2ef606c34a244ea8f94f5bbe33"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "95efdedaae8e6f46a2edeaac54dbf5537386eb336d7d61e791e80056521c0a82e928627d72c470133d098ffebacf7482d3f597ca652dce794a20040bef186a2d"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "7e1afbbddb6a04b5bf4940f658d458ffdbed2feca9fcc7972235cb4c4390ae6342215dc9f5fe929e10f0bb0a02fa5b4f"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "0d684e658f89774d4a411e12c8de00c139895a8c1c5bb2d43456a0f1f2ef64daca38ac087b5b8ac64d1454768f083c9e"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "6b45e05e842e370451f3e4d11d6b2139275ab6f46abd1ae090ab87168d58d5bc"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "3368e0b42cf46775ce86e9833a7e452a5a5f7d83410565c0b8753983dc3f0cb6f7ac4ded176df89f35bc70560a20cb60c8a56ab9be9c566fd9b8fb5fd908f616"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework/spring-expression@5.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework/spring-expression@5.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "Eclipse Foundation",
+      "group": "jakarta.xml.bind",
+      "name": "jakarta.xml.bind-api",
+      "version": "2.3.2",
+      "description": "JAXB (JSR 222) API",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "dabb40ba58199304c640b7bd8bb2fbac"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8d49996a4338670764d7ca4b85a1c4ccf7fe665d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "69156304079bdeed9fc0ae3b39389f19b3cc4ba4443bc80508995394ead742ea"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "5a9a94fc323aecc9c5b28e9ac688aac8d09725d4cae660a57f5698914db91e351283dfe4909a2cc6de803890ac2b3b9f06af9d071d465031e55326a1085a11db"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "78c5131ed2926819aea1a8a59d78ca9a9fa7e5e8da05a0816608bca4768569202b15b9666e5d608ef1611ecd409dca90"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "cad8a0f18bd947886b832dbafec2e6bdb5c69c8694aba41c4f075ac54c5a8aabbcf32c3f981e0b657a390813a7cbc5bc"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "5fe06acf4a556c000d128a93f91374d080547c3c0f7946c5f42cb198c5de5764"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "0301ccd4fd04c2e01c0ee9a6cff68f297689db0c3c3da44eb302dcf6b03f24c811bc132460079ce52ff8b522100df23a955c950b68c0a89e2ba25e34baf9bcd9"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.2?type=jar"
+    },
+    {
+      "publisher": "Pivotal Software, Inc.",
+      "group": "org.springframework.boot",
+      "name": "spring-boot-devtools",
+      "version": "2.2.2.RELEASE",
+      "description": "Spring Boot Developer Tools",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "9dcfd88040d6e14ee2c4d8f180b45755"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b72b182af53fdc10a0dda71cd20d37f357872de0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2b72f4303c1a3d6eef7eea43d4c7a1019b0310fee986b94ac08854909d66c3b0"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "3ee952ad796a2d620596fdbc8a4319456dc6a9d42b76079ca115f15785156cb60ffcddc624aadfa8f9c4ad71565f7cd7490a049cbb204812951fddeb443f9d16"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "f82250e5013efc5f4d6985a894d6f7b5b1325c17a1f510c3494f5ecba020ef723c9cf2d549b8f12043ac76cfc3842b24"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "749a8007188fe741a687192d16aa47dc1e88955fa98a4cde5e9c8e999b55c3a231f904439a78c0f2b4bec79a609fb1fb"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "c3e50a2641c31976b283d585b60722b78518ad52f6f55ed055e715f536d1a8ab"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "86a24c604824ec4065d73c92728f8a4f4e792f2ae1e7e7d35f89c5b0ddb7f90e042f787eb06596f65ada5e063cfbbbada8c863782085501ba277c765d29a2a1b"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.boot/spring-boot-devtools@2.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-devtools@2.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "Oracle Corporation",
+      "group": "javax.xml.bind",
+      "name": "jaxb-api",
+      "version": "2.4.0-b180830.0359",
+      "description": "JAXB (JSR 222) API",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "a9b97f6723902f40287c02980aa66eef"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b54184b7dcab2031add3f525550c7f1b7e12209d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "56b9e9702753763007435162ea788055efcfefc86ab920f032c0411dc547b836"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "1d9e270e7ae1ab6bf3ad8c85b044096a58716180daeb9ffa181230b1d8862812954d4d2d3162b24cb2f1c947e998a186581259094e05ad875416488ca7dc3932"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "5da90218790c276b99e13044e27aeb4f03b51e3192b8f9ce13b8cf129894c7a0ed78759d1e21d8b28414c72c2d16e43a"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "9018d3442f4d9d420a025613f7a101f9fa5dea513f98e0711b279e797c80379f4803e8699e6b632904f41a4d033315f6"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "67f73c364ec5d46d5c0b92a7eb8f2257b11f6ba03ff3d39947a74f72cb5522b2"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "a5a6f011475eed70062637ed6eaf7c62881c93a2eec7157dab1a0eb2bd06da57fe5769c3bf3022f66b9cfaf77b69956bb691928f06ecaea3c061bd0a686b87c1"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "CDDL-1.1"
+          }
+        },
+        {
+          "license": {
+            "id": "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl": "pkg:maven/javax.xml.bind/jaxb-api@2.4.0-b180830.0359?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/javax.xml.bind/jaxb-api@2.4.0-b180830.0359?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "javax.activation",
+      "name": "javax.activation-api",
+      "version": "1.2.0",
+      "description": "",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "5e50e56bcf4a3ef3bc758f69f7643c3b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "85262acf3ca9816f9537ca47d5adeabaead7cb16"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "43fdef0b5b6ceb31b0424b208b930c74ab58fac2ceeb7b3f6fd3aeb8b5ca4393"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "8ee0db43ae402f0079a836ef2bff5d15160e3ff9d585c3283f4cf474be4edd2fcc8714d8f032efd72cae77ec5f6d304fc24fa094d9cdba5cf72966cc964af6c9"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "d38a6af7ed00f13de8b46d49b9592af9b67adf3df47ddae5e4672f989f3f39101d446a77d1c11319acf8ff0a5b4feedf"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "cfee76de5976d5994758a06113368092f09b0729d753b99969d6a5ec32919428bd7c270c98cbbc682ff8ebcf2b93fd8d"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "aff48d0f28d8a99690c5a84c3fffdb3775452d5387e5698f4c9028c92a3b4888"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "0507ece74b3147de60a830071bd434569c82e03f414a2b7f0d8a225dda36720d2e2194799cdc04def1909fdec21059b67c518bb9162f7f605764d542194e721d"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/javax.activation/javax.activation-api@1.2.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/javax.activation/javax.activation-api@1.2.0?type=jar"
+    },
+    {
+      "publisher": "Pivotal Software, Inc.",
+      "group": "org.springframework.boot",
+      "name": "spring-boot-configuration-processor",
+      "version": "2.2.2.RELEASE",
+      "description": "Spring Boot Configuration Processor",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "3b6f9f82b47f1b81b1f756b35c202a2a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "7287179587c8cb2e469ae5529338e958af9dff75"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "6cf153059767f05ec02f58e913c2c2af637c404c9a1e5a84d586ac033ad3d67b"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "5aff8417075f984153c4163c4861260405517c2e683bbd422340701e88210f4b89edda4849bae4c3006d6cde1540b1fc7bc793933e64b0a989bfd47b2dd71104"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "6ab9c05d301ad19fee1add1d45e3d23233e23d3f6d4eb4b1feb3fb37b6b2845e2fb1c1946e18215b69d7bc3db3aa00c3"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "14bf9aabd01d9f1e10ae0110419233aa93072832ebac7dbce0a97fd7c852c6478905e033a88f6309ad78e60d605d6dab"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "027fd6906913bd82b37fc43c67facdf85cb337dc6e2d615a3c7493f8fabc5b44"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "7b7717dadb5028337552945c14ee67e89def92ca776f6df1f11aa300efae91db8eeeb3261f0964515409c034e1508fe7f65b1d6b56676fcec26d993c9465e490"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.boot/spring-boot-configuration-processor@2.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-configuration-processor@2.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "FasterXML",
+      "group": "com.fasterxml.jackson.core",
+      "name": "jackson-databind",
+      "version": "2.10.3",
+      "description": "General data-binding functionality for Jackson: works on core streaming API",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f96c78787ea2830e8dfd3a5a66c4f664"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "aae92628b5447fa25af79871ca98668da6edd439"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "50eec40443f387be50a409186165298aaadbb6c4d4826d319720e245714600d2"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "f89199c258da5605f9717555bd9233b942fb87fbd6a7e9d853f5fcbd754fd513db94c679ded1b4ab338bb57ce53e27543fb661452c8d1fed8c3cb3c68e5b31a1"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "494bd8c07cd2520fcee575f16edd0817e57d9940dd3d50269d386cf0854735cc2377130f4f4b3f6d9750f35caee52c7c"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "f04f36ab77421a167a96b5aa057d8dcd62190d5fef495ab3c18c8274e84a143198aea55b5995ff12f9df3fc2a25dd6d3"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "f1f39eaa603882029ff666e259b58ef0ff3b13b163dcde4a709840bc9798e1b4"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "50f97609b5b7ac87342945aa1e4bdc0ee411c452ac3079c8fa339e316a429095b2cf375617d3c1483ce4bd8ce970a0bf0c62dc8da048f700972a24549e097a97"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.10.3?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.10.3?type=jar"
+    },
+    {
+      "publisher": "FasterXML",
+      "group": "com.fasterxml.jackson.core",
+      "name": "jackson-annotations",
+      "version": "2.10.1",
+      "description": "Core annotations used for value types, used by Jackson data binding package.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "49683a3cf8e92c00c24262e8fac64ee5"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "54d72475c0d6819f2d0e9a09d25c3ed876a4972f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "673f8ae16becea4fa937404b3a851417faf42df3bbc592028bbe2bfe0cc9d8cb"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "4bfecbbb6d98bbeb5d42ec549740944ba0313c9917621d2567cf58a8f1bf4f4435b5f7773e2d0ba3542a71a01c92b62a57e6757e77b21c2138822ef794010fc8"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "f65285b3dcc4f58f4b7b16c48441202065ea736ff1e1b415245abc6ccf8066e17fcf817e8108ad072d60fd1688c1a857"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "12d99097c0f5c8eef3a0a2bd82be5f269c2bc62a20254700b88b7adae56b64eae9defaa893b2d74731461e8a31e95392"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "fa8bdfe16e3091ac0ccedbffb60b0fb8b0fea2937446571133612a20981b115f"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "1a6eb0e453496e824783ec044426ecf963c1df7b873eff9eb2940348296bb63fea826ab96429d9c50873ad95d652986f210f5086afa0e3b73353d2f9ee7ad810"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.10.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.10.1?type=jar"
+    },
+    {
+      "publisher": "FasterXML",
+      "group": "com.fasterxml.jackson.core",
+      "name": "jackson-core",
+      "version": "2.10.1",
+      "description": "Core Jackson processing abstractions (aka Streaming API), implementation for JSON",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "5bc20efba282bb641e3b42de153e45bc"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "2c8b5e26ba40e5f91eb37a24075a2028b402c5f9"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "79bffbdcd349f69a5ac252e2b4096131704386af4fa14d95395ea9a0e423cf33"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "34a22d04848fed91e94f6ab8b5771f2eb83ca90034858d33f721d938cbdd1835a5eea952242c1d6ee3b0f4f90d23643ab00a67bf3e8631d27c2452c654723e65"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "49a43f11fef6b6799caaa3895af009dd408ed68fada82b47680177ed89d5ff6e83427cb0f093ac7ed89f91ca51803b48"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "87a910626d5383ce9845971543b73524e6c0f70086c859ee9f08c70e5e28f99fc48b52d1f75838271b35d89b932fd949"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "31e74f35abf177171f8608c2a29dfafec633d73cdcc3f184f90b27219a749747"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "3cfd36664cfef265102825fb59981f52eda7a091c03c3568d534d336d06e82b49f6cdf20e14dab6978800c4f8965c7acbba54f5e43196afee7c8dd7cfd0f30c6"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.10.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.10.1?type=jar"
+    },
+    {
+      "publisher": "Pivotal Software, Inc.",
+      "group": "org.springframework.boot",
+      "name": "spring-boot-starter-security",
+      "version": "2.2.2.RELEASE",
+      "description": "Starter for using Spring Security",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "507e99f480548dec814fdc459b2dfe33"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "4644039ba9ff9e74b41d92a715d7e7640ba0e7f5"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "02e14f254d801a662d0e83490a4e38a137775b217a8350a766cede0f7f7212bc"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "8aa6c807aa61750745788ee198ccbc8c9c2e390f433410ed918c30d7a089af25e73e959d570d2d87c83528cffd32123a9c61862c686bf957615ce1e6a3e4236f"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "6327983ced4c96cb602dc9c0821acd099dba766dfc272360e4551bad6f7b38194522053d8043e156cf61bbbbb0458e76"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "6d917e9851f57c23f21c538c06dc890f44ccb2b9430614472ca8fd5c2ca17a3d53d6e825f8e971e59d0c660b1c067800"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "15cdf772730f16f1a34d40ceb81143cdc3a8f3fc920948c50c905c947e218fe2"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "b5f451fe59c3ad8acfd11952458772bde015d2a382f2a29545ebe95fc2bc9393744071fa80ab785d44321eeb533562890512eb527c976f2233aa460bcf3eedca"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-security@2.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-security@2.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "Spring IO",
+      "group": "org.springframework",
+      "name": "spring-aop",
+      "version": "5.2.2.RELEASE",
+      "description": "Spring AOP",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "312eecf5bee066739670e2648e5d3cd9"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "899739cf7f338f6297aa9eb25ea8b16338fe4e6d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "fdd91ca946d7e8afd33edbdab99fe04cb5a62988fc6d95d60fdf1444b48b9c21"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "bb0f5193243266667bf98086a0be5e26b6e873e9e101b76f9571c2b1180a032c176b397e9311908abeb7f032943debd69b84d819f999377f137f663a69d00671"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "04f9278a5ebb1f5f723f73820091bf9830728f9df6e61211e564bc3e27dbae3ef39190fe57c836b9b1b7e44a04174156"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "6f2266db546ba7c29bb17951b8a8153587fb523621769e660d8b7c2f730144178782f06bc318f662f1f4c27749d6b7f6"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "dc11df4a46c19b2e545e11eed4e31b2f39716f9681b7de8c10b183356e302f49"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "784d1f782844b690c41c4225de85d27adce7d66c0432df0ac6ba4bf18691057274c1b9353106fc75aab71815b5c779200d5a499f362a3d94d8a7cf368e36a021"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework/spring-aop@5.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework/spring-aop@5.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "spring.io",
+      "group": "org.springframework.security",
+      "name": "spring-security-config",
+      "version": "5.2.1.RELEASE",
+      "description": "spring-security-config",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "cf21988164811c34c25c5d512d6d34e2"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8f49e12035d0357b5f35e254334ea06d4585cf01"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "83478f549c82c1ba9b3aa7f042e19c43b05cce6dbc0084755003b53b79ee8be7"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "c13f8fd350581083ceac42f88e902240fea8c8c848b40a3db70754cf4ded7b2f1f38bd55b85dd836ca4c215ed8858bef8a1b910cd1adb855646029e5509a8bd8"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "bfdb4d734a04ab68c2e3aaa782685c58408365ffa243f913d141ad07721b614e18a77e4b17eaa579c4551b75486ac5dd"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "c14401e4a53a8a68c850509215ffb5cae5020a2b5cb17735ee20df9cae8c70b437281b34e5d473aec69fe396588f1c88"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "2b619d02026d61de93f4ebd9b55a017c7260d75e56ab798c9d2e32c798f521ea"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "57e9cbb7ac3c7aa191bc488ce93e3986e8116998bbd1a44ada2abe9feeb4e93a11628afcb56174e420c079cbe46cf3372750cb4064a23834b793aa7e12bfe90c"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.security/spring-security-config@5.2.1.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.security/spring-security-config@5.2.1.RELEASE?type=jar"
+    },
+    {
+      "publisher": "spring.io",
+      "group": "org.springframework.security",
+      "name": "spring-security-web",
+      "version": "5.2.1.RELEASE",
+      "description": "spring-security-web",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f771efbaf1e50b4def5f3e019df021be"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9e43c2d8d2dffc60bfba8ac95a106d30e9593106"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "816e4fa4dce2e782b1e5eee5fd6d8ae75290ca92b894b5c504bda25a111a26b9"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "d2dbbadfeb92bc52d173f5aac3774c6fa9d32381fb271ef5c105d5c3fb1f613ed5b8f501fe1f69ccfc8535f106955a99cc5b14c0e4cb0cc4e396bd0164232c24"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "3e787ba98816a33e185787730c131b08cb3afabcd1daa39c29df0ea25b6d4fef5fb3e4178ba4101382666d25624637c3"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "66909193947b8b8f20c4ee098b291630c0e1adbcf570f07da8fec5005a91658bc3ad37bc87a138212091eabdabae14cc"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "bd0dc8c6430598a5e66ecb25ecb006c14d7a6dbc18b98e61b0bcc8739bb9b477"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "a72e2436b9ebb4575f5173891672d70359858ae991399da0b7f181221aaa0c3b5597f44e52c3fbf2e2571cdc45f40f61ca874733ff52c5582e917c4771224d08"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.security/spring-security-web@5.2.1.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.security/spring-security-web@5.2.1.RELEASE?type=jar"
+    },
+    {
+      "publisher": "spring.io",
+      "group": "org.springframework.security",
+      "name": "spring-security-core",
+      "version": "5.2.1.RELEASE",
+      "description": "spring-security-core",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "8dad6a85f53ab899d210ed36994528de"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f1265ecdd4636a2038768c2ab9da4b79961a3465"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "97e138c645df205b15e044a2e7fe6ebad0b5ce5ff9d9d4aacc689bd1ce828c77"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "e291ee5a16785ee02fc094798cb4c3226917a79008280f287a75e3183ecad5d055e4a056d4b3354001fe6149c523a0035c247694088c9195d60e336f1ac1a042"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "192400c83159eebd6f922108eefebae57f1de2cd8b402e097e870d877de55ba20f9c6ab3e0e4113680746806b8f725d4"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "a3bbb85e1dcf472f51b69070cb2741855ddf60441f3f8f10d77c7f1820d2a31c6fd17ec998552419c1873c4038a11121"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "cd4ae8f612212bf8caa0c7a4d8a36358c4928d6f5504d34cf4915ba3ee8cf583"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "317320f3dcc6890bf1c3bd6a7f7c1d98ecf2c38d2a25e0751c4293179e44c11edec5b2ac5bac7f1f09071ac8e0c0fb869704c0c00fef5288df3008718fe771d5"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.security/spring-security-core@5.2.1.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.security/spring-security-core@5.2.1.RELEASE?type=jar"
+    },
+    {
+      "publisher": "PostgreSQL Global Development Group",
+      "group": "org.postgresql",
+      "name": "postgresql",
+      "version": "42.2.8",
+      "description": "Java JDBC 4.2 (JRE 8+) driver for PostgreSQL database",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e6dcc1898639407bf530b7a34e870b55"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6f394c7df5600d11b221f356ff020440d2ece44f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7fb81e74f5c25a5c40a997d9b83333fdd3b5d63a0b3d61cba6d562c7e3a7f3f6"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "a532fc31fdbb5586c0974e9e34c71fd8943cd607c62d08e66799a94ec8ab2b509e679d64d2cfb6cc5a4b661f63b775d0554cf24911f20717e76b6d93bff195a8"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "7b89519ba3d692ca3362792dcf5904fad6ba0fbf4c3edebc719ce6fd9c402d8d228c39b442400445d24758baae92b291"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "ad851814852ecb9dae5b4404699ac648b1a82ff2e5ec594602f5f8aa24867ebd9a28249ab553df8cc1df85c48e003621"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "89cea473e2cfd31a9e0f5f0841aba191a0e6a0f3b13ba425509a154e3f9b0172"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "7458d3b3efefb6bf77305248ec728429d01d1ab597638aba818fac248ac07815fa2834cb0eeb404adbabbf4eacb4b205dcc6531a53757a56a6b45c858a8f6625"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "url": "https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.postgresql/postgresql@42.2.8?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.postgresql/postgresql@42.2.8?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "io.springfox",
+      "name": "springfox-swagger2",
+      "version": "2.9.2",
+      "description": "JSON API documentation for spring based applications",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "34d27cb411e654f3c2b69bf536984e77"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "362676bc7f4c6f9f1d568741becab0dfc198c898"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5341bf351c3e14e5a8436f81eeb2dc8f9f07ef83c8cd046b4e0edea33d0f8c52"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "de41cdd5fd6b9beb6e5fa06c17d4fb3e587bc18b0e3b5dc43ba85065bcd5d5c45504089836102cc4b103862db2f6dc297e5ce1b349998a58e1f7848962d56352"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "fd7d70bc0989fb2ba381737e238a1e6ae4c75f4efe0d067a52723333f6069ad3a1c0f95b7a38f4b7e5ef28325656a645"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "35476f9b307c12f96949ce114bbe4588e0549908ae11751779d8fdf6c93d90a3af67bcd8422ad5e6b6780f3affe9c89f"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "622b9a7069624f07b8a2082d930e939b3e08316614f538d30fae32778c7bb5cf"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "ded4b81e6c22acda50f955e879caecf92362d4faf4f2d8fbf4a03e3d6e16a87f5dae5970278ad6d16242946d6c236ce0ead7eb32717864f5a38d8fe421488cd0"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.springfox/springfox-swagger2@2.9.2?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/io.springfox/springfox-swagger2@2.9.2?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "io.swagger",
+      "name": "swagger-annotations",
+      "version": "1.5.20",
+      "description": "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "619f94ec2cfa0276622657810eada472"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "16051f93ce11ca489a5313775d825f82fcc2cd6c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "69dee1ef78137a3ac5f9716193224049eab41b83fc6b845c2522efceb0af0273"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "d53828e0a4cfb0467dbe3870c61b82f19906d98171a798b451edb5b2262a2c2885e7376c8c2363db114f078a5d28550b88499d0e25d6a238f06b6312e2c9c953"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "d1264155c7f63bc8cb110e1a65a045765f7c146be60bc21868604920145e105da3c737ebd8447a63ea892f6240fcc881"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "54999315ae82cef57e79989d20a5cb34d845bc6245bb38442b586a19261de584609dc7d1ea655c0e97f677410f18d7f9"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "1a5afadd04622d1f91e25a8ac271b54403f277d834b49b6e8898a3fc401d9194"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "dcffc7c6a72a3c9d5249d8d0bd936cabf96ae824181b014e6cb242b9b82f6a0ad74532ea7f59311601770bafaa27694dd0685f1eb4d4ffb0034298190d4d186e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.swagger/swagger-annotations@1.5.20?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/io.swagger/swagger-annotations@1.5.20?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "io.swagger",
+      "name": "swagger-models",
+      "version": "1.5.20",
+      "description": "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "9a816507533880637936bee8c27b238e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "fb3a23bad80c5ed84db9dd150db2cba699531458"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0adbb590fc665f17594f8bc7acce6871ed5602c8a50d0ad5419e3b72efaef639"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "9a5db9d57342df308b263e4fcfdbe8e744bbd42b964c249a1788a0c64225a86377a6c83164f8a60e6e3aeda1d68abdcac6cbbd9baf4300511547c3f49165e87e"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "346f83bbd71690d2802dd419402c341e6600b3ce31e14dea54a47180a7af6ec41c04ea9c8c128a7f909218a31310c8f1"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "3250092c26c8a7db07bc68f577e215b3edc43ecb03ab9a9a77d7d844a3ac2f9b0d0c67a84964bd63e1e65d15395a651d"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "c4cf93f342ecf6eb813c6d12f27ef5abd98628f066bfe68ae09d0ebfb4886c03"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "14c67a98df498a5cb03d7f8956ce6d3f063d316a12c768ed856c25c99c266dd47587de571ae101c7e9a2eae9b7d2a57bc706b43db42315117874896dbffc513e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.swagger/swagger-models@1.5.20?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/io.swagger/swagger-models@1.5.20?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "io.springfox",
+      "name": "springfox-spi",
+      "version": "2.9.2",
+      "description": "JSON API documentation for spring based applications",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1433cbbb72dabde215e83f1e4faa5cbf"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6ac686190a6ceaccdae8b50d03b0501d144a6666"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8e0d6a9ef7b75060f2fd1797759880d259b292c159043bd624d68f1b57734d79"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "d066e32a4c028f83982c1e9a98beaffffd29723b159d48aae45d7f14eff27d3a5ba21d161a6251e7f39b1f7c89fa29650c82c33a8773ce09bd0aa6717153868c"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "0dd66f8f486a5bcfefeb66901946c3ce2c2dfa3da542f4073e24c67b4c955a717f251084a98b464d4e375154057ead00"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "6bfb649de648fa0849c8c060d94ac49f256c6e9253c91a0973d1294a64072479fceeea93ab6b83804ece55cf52a06e9f"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "130056d9d1335c916cde3daecf9444282a7ab8ad3739b8e80c3bb00b7596b157"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "4f04356cd9256cfbc01a7b384c15a0e0fd127f4eb5817191307f9f309041fbb003c5d92b61f9172f3f34de65226f54f402071f38a3d2424255231cd4cf2cfae0"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.springfox/springfox-spi@2.9.2?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/io.springfox/springfox-spi@2.9.2?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "io.springfox",
+      "name": "springfox-core",
+      "version": "2.9.2",
+      "description": "JSON API documentation for spring based applications",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "28b0d37b0ce9483597466f49a37ce562"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "2e26f58939c594fb5c958c3a1c7bedf83d2f2702"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "70ed452095f0cf4d916d4f5120e79f9ea7ba609f4fdfb1f6e863227c20dd0a0b"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "c028faf5125bb104d2f60ee1c852f5fefd1a1eca33d536ed6c0d7033c39bcb9c448e22efc7ed9e1d9eada7d4356033a326caa1b2a1cd1e19ae9fdf58b185239a"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "f661b0bd67f1023ac74ba0aab311c465c75db7cd9ac09cdac1475f41c83d6ab57ef2a204554e146bbec34cb1b432f848"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "292fdf411d82fd43e9f1e04b0ccc065f432003bc543d5ef38dc57a0d11bfffe6f907c5e9d24cc1498f917e1b55afebae"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "7d4ca438738291aef82e82a6418310caa04c1a39d56523a94f281ce12e8933c3"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "895679147b404f068e27aa7c7494d4b07cc4a93fd8b851d1b6831d0b6590db005e0aaebaa91e7654de3c02e3c30c652a8274fae76de28094d7cc091ed78936dd"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.springfox/springfox-core@2.9.2?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/io.springfox/springfox-core@2.9.2?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "io.springfox",
+      "name": "springfox-schema",
+      "version": "2.9.2",
+      "description": "JSON API documentation for spring based applications",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2d5a141a7c85c9b82acb4c16710c36ee"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e268f38774b16bb51a92ccaef0dcf3dc651c0cee"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f289487967890dbb3698aaa9eaaac656c9bb9e30ee8cd399980ae8d8f888783f"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "e24522b36cad2c6c5d53c331b227e067eb1ee8237ca4b0a7427a8379b24e80dfde272103842dd367569b871a7fab7e37a7ec5b03dbc81f678804d651fa083ef0"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "16ae9b13582ee500b6ad8453decc32193ba0df772ca7c4038cdeb1371ef007ace2768c52e9367fac85170aec684d442f"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "091c29452450b6f9313518777ec186dbd538fe1b0660316e0e5799ab3fac1526472b6159cc1854450b101153e8a9f018"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "fa5e176e5a00d355fa3d3180e612a59b7b227dbe3fad780a9d06aa7d2203b17f"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "0b4f7b4c27b550d7f17f04dbe8c1a97bb9149f2356e23f2f5474126b3bb435380a37a643a18140a252b6eebfd615ac19c05b7bc53e19ac557199a074a19d41e5"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.springfox/springfox-schema@2.9.2?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/io.springfox/springfox-schema@2.9.2?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "io.springfox",
+      "name": "springfox-swagger-common",
+      "version": "2.9.2",
+      "description": "JSON API documentation for spring based applications",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "bd3d55991beef2ca5e98ee61215c33da"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b38a41b3044af80cb7f41f67be5d158c9f6491ec"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1d8534e2d38f989a84900166264cde966e9368ce0af74ce5ddda48ab6cd744fb"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "bf5adb24cd62cc779f1baf15f251f92397be082e918e00cdd98fbc732207ebb40c32d434b85876b5391b5683baea351a7a27dc457ae3e9db2991b2387bd2d9d1"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "ab34cdd1ee3d84f2b91133f6a7f7b544280a8ff56df23f012a39d74330e36677597f37d6e1da732fcb1d2afafbde8afa"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "8434fa3ef243f242e96df94da90d74254b8d08ca00b4415f1684f00ba88a237b43abcc9fa1c9822719333bb18f51191f"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "8a9a5a6fe0599b3e3a52127d9b8fbe3540c6f07f0d566cbdb87177d322c16229"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "50321d07773f093a7ccda241b6403f606dcfde02a55912dea8900e04ab366183a46ff598344ab39981c78cd42bee0f9de6d4ceacb70eb76f7eb3b5b20bbdc19a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.springfox/springfox-swagger-common@2.9.2?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/io.springfox/springfox-swagger-common@2.9.2?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "io.springfox",
+      "name": "springfox-spring-web",
+      "version": "2.9.2",
+      "description": "JSON API documentation for spring based applications",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "427322d64ff9ce6fa431afe35329f52b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ed2ed714a6cba8804d00f80f0534901e4c7a3211"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "df925e7a2435de246afd68b83800e1f2a4b6d8031692298740e261a4a9b30b3d"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "a0c6530efa068732ad76f5f301e512a371590d35a2891447b42dcdde59cf42fd25960cc142bcf3e758a710c9d53801737601d65966124952f415788503f0004b"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "bb1aad6ce4b3517fa9d1b41169dab594e2d4822be4e65c2eda1a99b89bc2822743b8fde569002454a0443a71d470fdf0"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "8571fffc95559d670e3a35e6273bcdd9b66b233fefcbd9a4fd054ff5d23e007f269dfabcb1d25393a71970decb21beca"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "2d7e7d7e0d7891759a68b7426f34397763fe5a02e6c0a01454dcb2a16c41e523"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "b1e52c515e551f7f39ff3a370461029f755a6f6d76e26006ec7fcda2d3403616ee3c9275fd82bba8319c0b76ec053f959b4ad08fc5a6b030f796e63280d57b58"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.springfox/springfox-spring-web@2.9.2?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/io.springfox/springfox-spring-web@2.9.2?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "com.google.guava",
+      "name": "guava",
+      "version": "20.0",
+      "description": "Guava is a suite of core and expanded libraries that include utility classes, google's collections, io classes, and much much more. Guava has only one code dependency - javax.annotation, per the JSR-305 spec.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f32a8a2524620dbecc9f6bf6a20c293f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "89507701249388e1ed5ddcf8c41f4ce1be7831ef"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "36a666e3b71ae7f0f0dca23654b67e086e6c93d192f60ba5dfd5519db6c288c8"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "d8736b5151df2dd052c09548a118af15a8b8b40999954cd093cfd301445accb8b7e9532b36bac8b2fab9234a24e2e05009a33d0a8e149e841ebddbcc733a8e4c"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "23b88393eb8728de962a5108e2d73acc8f745f52ed692a59238dc029eadd20719fd6add5f06a2196d11d43800c334f89"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "474ab51ff1fb1e047e29791b77b39fe3b0f1ec0eb0da6e0a9e0c8b105fa785159c0e09b545c2e51ea62506f1f73f584f"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "33c10a1b58e8cdc9cb4a8c93cb407f98dde9aa324fd9c21054611163d0a2524c"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "03aacb9e1539c58558b9cd712b0b72bd61d5eb48ebf38da1e20a5fd66eb26c7e396b713a57c0bfd3400054b25b3690c94e30b8f0a511bd27ab3a2fa706ec18f7"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.google.guava/guava@20.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.google.guava/guava@20.0?type=jar"
+    },
+    {
+      "publisher": "fasterxml.com",
+      "group": "com.fasterxml",
+      "name": "classmate",
+      "version": "1.5.1",
+      "description": "Library for introspecting types with full generic information including resolving of field and method types.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e91fcd30ba329fd1b0b6dc5321fd067c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "3fe0bed568c62df5e89f4f174c101eab25345b6c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "aab4de3006808c09d25dd4ff4a3611cfb63c95463cfd99e73d2e1680d229a33b"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "7fc4764eb65227f5ba614698a5cf2f9430133f42ec6e2ae53b4c724ee53f258541a0109fe0659e0b9e45729b46c95c00227e696b8d1addcd772c85f877658c9a"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "28b4780b2353ebc08dbc02c9a343527a9062a0455bfb4ab135cb639c03e5dfd9c2250a835c44d5f17d275667c2009694"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "b194ace8f1f49f410286bd859866678b95a1b2c6f73e41f48291eb7438dffea57aaa9b177459038b6997771ce4d1cee1"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "50234c94efed4c816eb77bd2f70b869c9f89ddf8ee73dc25e354f4d0b81b3e1f"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "9886421726066b313a62283a6811b76d904ea1c1e9b7b2d850cb47afa189b03cdef053c8f7f6b79e77f2269c45f8cc2ed75c3389e96594b50987fef311d5a25f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar"
+    },
+    {
+      "publisher": "QOS.ch",
+      "group": "org.slf4j",
+      "name": "slf4j-api",
+      "version": "1.7.29",
+      "description": "The slf4j API",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "75191c97f2d6ef4f990cbb4b2e56a46b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e56bf4473a4c6b71c7dd397a833dce86d1993d9d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "47b624903c712f9118330ad2fb91d0780f7f666c3f22919d0fc14522c5cad9ea"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "ca99cb8f73875eac2fbdb8b13b9801d1299dd3e93556bd002ec2f2c906fd88e4450b9cf4ab025951944fc490d03ff691189fb174440bd3f404e9717276b6f9e6"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "7934cdad41bdd66f9b7550f8a94234d512a1bb856998b397ffa699a4a3b6deb8530f7bf91b682ecbdbe7974a52d9fbc0"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "2f2cb6b01f32fe48ee0cc17c2d5dfd2719909bf6ab666d38db077da70158723c91beea9c8e915dff31df2865e58bce31"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "42ac7c13afee24f405b4c295c2908d3f91d5fd72882a8bbaeaf4534671065ff2"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "695ee03575e0c3320ab1e2ac7ce9027d734dc41a4b433d9bba5040575362bea2cb06a1711440b9d6461226e28b725a050d408110dc0dae0ba3bcb8f49631d7ac"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.slf4j/slf4j-api@1.7.29?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.29?type=jar"
+    },
+    {
+      "publisher": "Pivotal Software, Inc.",
+      "group": "org.springframework.plugin",
+      "name": "spring-plugin-core",
+      "version": "1.2.0.RELEASE",
+      "description": "Core plugin infrastructure",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "4e6325e5ed2c1aa1949313c184d83640"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f380e7760032e7d929184f8ad8a33716b75c0657"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "de8d411556cccbb9a68a4b40f847e473593336412de86fb3f6f7f61f3923c09e"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "faa81f9de0a459130ba53954f1592d95a7fa3f62f205edd3cf96c2be8fc35aaa7685f837edcc9d359bce401c7d1eecf17abcc7408e506b490c6f2c344b6d9423"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "5b34d0db751f91b631b5d26faf0f25ba4a376b4541ebb56b59e6b13c2cc79beb2d1752c86cd633a8507fa4db0bf63287"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "6b08b573e89910717b01a6281c8cb577a89901933e7198cc1e47a47a00ffb062d36afe1e5480b3539ca3e0920e291ee1"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "1cd69d68422565cb996929ac7e144ea84c2addc6efc0a2417a4219e81f62c9c0"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "bac409ac4c2da9a66d11486f4b58d4b28809ddf5d57cfd2eb0b242e781e763ccfee7bd1763f0affd29d529487f886147e873bb4ecd66d534be9b21425138155b"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.plugin/spring-plugin-core@1.2.0.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.plugin/spring-plugin-core@1.2.0.RELEASE?type=jar"
+    },
+    {
+      "publisher": "Pivotal Software, Inc.",
+      "group": "org.springframework.plugin",
+      "name": "spring-plugin-metadata",
+      "version": "1.2.0.RELEASE",
+      "description": "Extension package for metadata based plugins",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "63a461c6e878b1a510f0bb5c58b7ade7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "97223fc496b6cab31602eedbd4202aa4fff0d44f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "aa58a6e6d038553b6bfae03bd18cd985e4bfb37cb2fb6406551b87f57283b00a"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "6f729019cfb761114c813fdcb5ca645be410bc58e8f701883f9793cf5279f9675376fb337548b25fd21f9119cb832048385295322eb608b25f87680346da8821"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "182a79dd5d4c26654c2524ad254760fde3e2b598ebc395558d6ef0c14fcf28f6ac4bf574ff4ed1228f715b421978ba39"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "fc98e1d69c02682163e31ea8bda268629ca360b6a999f583a5af90e8f1a57a68bb43815f630912be23fecdf03dbde4ff"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "0bd3273662b1f9b86bde8a1087d9b167782b69b878e48bf06d1ce8cdf0642b4e"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "bb14a93566593a37f4289454bee10c4092e9989582c4472414c9d75fc84788e1cd6a6cf454c24cd1efd587743663a89efd05a522502eaf920dba8587d16b7dff"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.plugin/spring-plugin-metadata@1.2.0.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.plugin/spring-plugin-metadata@1.2.0.RELEASE?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.mapstruct",
+      "name": "mapstruct",
+      "version": "1.2.0.Final",
+      "description": "An annotation processor for generating type-safe bean mappers",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "badce92967671a310b5356f009ea57b2"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8609d6eb044e9f6c73cb24c8f2f4ed5c72a249c7"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "a3d2414cb7adbd5ae9b29bff5197a42d6e48bdf68d9798d437f48e798abd2309"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "cc0ea220cf083183f7a4d697abff9d7db55558e7e37f904f02a8b94ecd94c8b58f0a54a39589a9320bdbf70160cebcc27611776e76e8163308aaa5073a63d50d"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "c48f2928028ea61ec210ec76a8d823d7d0de1a51334ddd4b4deca5f8e5e77587b4ec223fa3a4edb4129bb3e4b11da3b2"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "d5793d128f99f55c845565d16e05154953d55bbbac1861102533db7245ee57112e1fa7b3d90e1beb8fab577f3cfe8b55"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "cfc776a0fb309303408941c3816afe0beef86c4734e1ced516f656424597c045"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "481dd56753f0a94d7612230e875f262111fb29a7e0ce14c91888947fa9d22569a8b2df0f002260462c54f3455547704f58a65c07b3c2bb7c51d93e6cd72bba0b"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.mapstruct/mapstruct@1.2.0.Final?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.mapstruct/mapstruct@1.2.0.Final?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "io.springfox",
+      "name": "springfox-swagger-ui",
+      "version": "2.9.2",
+      "description": "JSON API documentation for spring based applications",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "83e94205067bcdcfafaaa4e08f38ef81"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d542382a88ff3ea8d4032c28b2b0325797fada7d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "44ee72b046428a694c44095c60f8156bcc505faff2d5b142b0f8175a6570b307"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "132dacc2c6825a151ada93ac8cb1df43f31d4fead28518da28a58b255912c230192129fa9061a16a7fd885bf8ea33d4a9250ee8b14d3fdfec0de76992b1ba324"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "d225cb60da91ef1499eefc1318a5c7f7007201fe40700c03b04dfea55ca753b8f9f853b210cddd9b2a3d421f2b3db608"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "cc557eb7d76d2f4570796ccb0be2c111e85ebd4c68faf47178185c7b2adb535d31592df6848fef49b1fe1c71ef185921"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "6c1cb4ad23e53a5c75b2db1ce83707e534f57843a4d63a5a4f172804af2a46b0"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "305c1be5cef19f591b20c46a311401bbeeb0b83d7c3901f2a401a3eefe0b302073234548758cc9d2fc38c30f692a502732f8d9714e025fc9251fdce2972bed9f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.springfox/springfox-swagger-ui@2.9.2?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/io.springfox/springfox-swagger-ui@2.9.2?type=jar"
+    },
+    {
+      "publisher": "FenixEdu",
+      "group": "org.fenixedu",
+      "name": "feaf4j-api",
+      "version": "2.3.1",
+      "description": "The FenixEdu Api Facade library",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e26b70619b5fa9f74ab67e7bb61c41d1"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b7b75a522cb1d3865c50870056d3732eb26c0448"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "601fd7e5ae30f2e9966acadde5634a65d4bb41fe191b37aea931a574e69ec846"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "e74617b9ccacd0003bedc7331e5bfeee1dcd46e4c2337ef445073a875d33fc6704678d743eba055bca25071e9f9e9eae46911935a1fa7fdd06524c14edec0555"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "812dd12d89b2130e6245e7bc6a1824846d8d93b3172752dc45b25f62568fd61d54e8c40b55012ffb6291040f3359f339"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "7e417d73b53da39f66af734e787d8d60131d0a384f1d2e4d1fb051390ed3ead90bff1213e9042c04cbf348a2ac512036"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "1e33f94a4dfe70dc2e6afb9888caa02b84d769ae21fe9f53656f36f94d25886b"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "979775f65b2f8a0a0941bd7cd711aae17cf518761a05889699cf61f5c3a2dee3bcf4ad2f6606e2c83423a51916d3a7e30d1ca8b82ea188eea1dd8d83d4b8a5b7"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/org.fenixedu/feaf4j-api@2.3.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.fenixedu/feaf4j-api@2.3.1?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "com.google.code.gson",
+      "name": "gson",
+      "version": "2.8.6",
+      "description": "Gson JSON library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "310f5841387183aca7900fead98d4858"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9180733b7df8542621dc12e21e87557e8c99b8cb"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c8fb4839054d280b3033f800d1f5a97de2f028eb8ba2eb458ad287e536f3f25f"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "902a1a5dce66303abff2ac4b8a2319035f718c42590c1ae593825cfb85a0003e52c3492fc7ae6b86eb3ed16656dc3fc6b918aa807b20b759d4753cb692031740"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "8289cd5863d035279a59fdf47febb53e39aec9bcb3da8bee14fc9911ee78d52e801f73ee3795cc00ab146baaf78f6181"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "f0152ec3945a39511db66831bbdb87b685112162f28591e9f99e4bea602a58da183f29d8135e9305627e795b798b5906"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "8ed3aa4fa98a5ce64ecd36a22576e2e02284edbc409eacb8ff499e5c2cd3dd8e"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "8edc61bdbd833a94238769cf7a0b63c1cd11ca2581ac4dff0f4bace389d2d321254df3568759d06b8ab5c0899fffb4359b29fc9e511a81b466f6b18e980b6a6e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.google.code.gson/gson@2.8.6?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.google.code.gson/gson@2.8.6?type=jar"
+    },
+    {
+      "publisher": "FenixEdu",
+      "group": "org.fenixedu",
+      "name": "feaf4j-okhttp",
+      "version": "2.3.1",
+      "description": "The FenixEdu Api Facade library",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "bddd41c0b3c766915b14116e0858315f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b4c4944fb74f93a2b4866ec4f954a10d200dbada"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c02e561d9d3db57821487fb968e500fe1daf88f9b6d0ddbf20f24994c5a38476"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "d70f7e98c53b034566ef7383d5f9a427047264fc5bb383660fbd7b01705ed3fcca5b8af55af56f043cd0884182689fb0384ff48c72a4b71fd77d3c66d1d74cee"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "98636f661146f3d80b5001b3505efec731f1f128de299f8bdaa741b2d0cad9a600b598c5628dc87077406fdad27762e2"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "956e8459613c28fb556f31e3548484d0e5ccea19198a48bd414ab05f5e292a23e3d263e57ee0470db2e8999bc1ab5b6d"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "ca597629d0ae24e312f4f1fc6d4175863e556065b14f9c1309d4f74368caac90"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "96393fcf4161fdd6e7bc3876815ba36ad9411c6930377beed513d2c1916780451ea50f334d61a92d92bbb6ca6bec68fbe95286da54c3763aee3d47e656b1e540"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/org.fenixedu/feaf4j-okhttp@2.3.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.fenixedu/feaf4j-okhttp@2.3.1?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "com.squareup.okhttp",
+      "name": "okhttp",
+      "version": "2.2.0",
+      "description": "An HTTP+SPDY client for Android and Java applications",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "75d3aa08eb53cdd6783296d23a070e92"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "959c454243581fdf730abfd4f4745441724bcf2c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "89b7f63e2e5b6c410266abc14f50fe52ea8d2d8a57260829e499b1cd9f0e61af"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "ebaaebb82f710c8f4c92627d061974f5b9377691a577fec1a60a5ceb52217190019ce5250c595f8a3fe7dc66292244f08a47ce7b27af4e13af80e7b01502824f"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "0c693438e41c9441a4e2844bde09575c5b7f3c0d6b8786bfb135b8be73470094a090728b550165d5bca46734eda01a88"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "cddc58f0c689240ef595574c04fb35e6bf58596276d4ec5379e727cd807a85ec18ef792537e693a39f1edffe135ac60c"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "3ee7cc53280ae18f936fa87c974889a73b9829d90fad7bb2700ca5f835ca5270"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "e78bde45ec5f262a4b44ae0b9ea32dfa533af2748f82b973987a642b6980138c84f6676231a0151f234d5cb5890469e64a239498e6e612bd1079949a8f3eb88d"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.squareup.okhttp/okhttp@2.2.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.squareup.okhttp/okhttp@2.2.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "com.squareup.okio",
+      "name": "okio",
+      "version": "1.2.0",
+      "description": "A modern I/O API for Java",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "59261802fc33e0f866c6efe6f47de37a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c0b52915a48fa91b1b94a28d4a2997bac5f524df"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5e1098bd3fdee4c3347f5ab815b40ba851e4ab1b348c5e49a5b0362f0ce6e978"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "d0a5a9a9f2e62df3ad0422e02b9d4810b5aac9fb504371efa53ab3fe6a5dc2626250dcfd9e24db77c10b4e8db3dd6da675fcccb95120d063a71579c0ea8b3060"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "fa2304ecb365f4f8e2cbf7569df537b2672458d58534e01b99db0b9b130a3d10177c177aedb5d3ef6d69b504dfd3199b"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "16302c0fc711f6262098031e352341ac6afdbbf827b47e72a33fbdfe2e9776868606b0df5a87ce97fe0755bd7aa7794e"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "dd69b83fc0029ebd10e8e6941b4e191575b38cb1003cddb26f47003d7a71a402"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "b275ff9995174f3def9e2672f740d501e12bd70014f9399844f9aefadbe1e473f02ed00c257c7e8bf1973db2ef2b13ddced60d00c017bc7026b3c74f11551140"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.squareup.okio/okio@1.2.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.squareup.okio/okio@1.2.0?type=jar"
+    },
+    {
+      "publisher": "SpringSource",
+      "group": "org.springframework.retry",
+      "name": "spring-retry",
+      "version": "1.2.5.RELEASE",
+      "description": "Spring Retry provides an abstraction around retrying failed operations, with an emphasis on declarative control of the process and policy-based bahaviour that is easy to extend and customize. For instance, you can configure a plain POJO operation to retry if it fails, based on the type of exception, and with a fixed or exponential backoff.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "be72ef5acb43ebe6fbfce3a27ac71664"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "2d3bc6318cce49a351a1db97048b04e172e4f079"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "71e7cb0d33e3f595011d3e98b14f41ca165a435760ecd4d68cb935e8afa8a3d2"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "244e3531a5382f17b64d0234b5fa80522ee1af1a931853d4e2f9cacf903765134dbce1ceccfc476fe4df91fd33dea61b5a12e9495a476b640f0b17aa6be7568a"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "7bdfd87f1173a12726779d8ad0449cd766ae91a45dbb7417b7461c3884c7541f0d9b0557a1926cae01cb6cd84ded8afc"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "2f2910b690bd264926ca419e1c55647d042ce5fe7bb448a0df1388fff4a69034a0ba4617d43d6552a139cfb403a95da3"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "33a335b9dfa894a9c9d617c00345da994f7f3ae696e57974c72b4c605a554ffa"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "759d1defb7b5da56326cf7d81dae415f55d0765461caaa9c6078bead4c6e6632b09f8408322fd683369a7ca0a51f7a983f9d33dbd82c60103051921eb3bc5330"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.retry/spring-retry@1.2.5.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.retry/spring-retry@1.2.5.RELEASE?type=jar"
+    },
+    {
+      "publisher": "Spring IO",
+      "group": "org.springframework",
+      "name": "spring-aspects",
+      "version": "5.2.2.RELEASE",
+      "description": "Spring Aspects",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "700c5f739d765dbdaa1f2fe993bf0f03"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a7fc38ee5fcc7efff607cc93b5fa7259c0fbb4da"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "271b6ad316544cb6bf80904e415990e14eb273e32deee0b5c991a8e544c85414"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "4c06d6bf6d6d5deda9ccdd89d7b3e95153e854586dcd75dce68dbcd375d68072220cba5c4091245a24355a2e52b62b5311a6d588cc77177190bf4b0df5c26730"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "903cf475437a345c9593ae6357766f639e368727fce737db07751f3d04e273aa842dec425c735e013df56c1c4443df40"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "28f95b2aa173eec1917a0494ee63437fca7dbdbb7dc604a5058ca748afc8e2967f1cc75115ac64cdd2d3eb2b0c83deeb"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "a261f6cd3c8449e1725fb9311be35e4717222c4141b0a28fb9a188d7a7f528ec"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "49b2a4b5d92cebd38d675c925795ecad101e8264651e2f4cbd6f3d5f00cadc50187a6246b748c523efb4ddc659c35857a755ed5d70c6c22ef143d1740d78e1cd"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework/spring-aspects@5.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework/spring-aspects@5.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.aspectj",
+      "name": "aspectjweaver",
+      "version": "1.9.5",
+      "description": "The AspectJ weaver introduces advices to java classes",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6b83d30e2d1457422dffdcf9faa0b329"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "1740dc9140103b796d1722668805fd4cf852780c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "3ae596023e0789328fb6fbe404bf51746e21b524e58741e0f415be27c6f98aec"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "fc3b87657e9e4b3c1bf96caa6aab3fd4c441d1e9a9e789bfb76f9790e09f05f1f8a47246d2f9cb04fc5ac6c3cc0cecb86bfdd73527a5b48e305cb09a14bca72f"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "0ed5c11a46b633d141b499b9ac2faf792a5cbba60b713b09e093348fbaa10c7dee639a6c82ca39b6298968aeceae63d1"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "e39fb782f1d47242abe46530a9ca5ca0ad2f7834e72bb466680741f64241acff5f463c5e6d490d611857f4c41096b7c9"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "53bbb02535beae84b124dbd77b8f85c3734adbe1bc3421f774016e782ae67bed"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "f9a973a8db6a8f4ba8aaf887f0dd907d8ffc979f5473ed79fa16510d71ddbf082374e8c91d2b4b8c3e814b708842fd2d4b060fc7dca2dba6827d5c6c1fcc88b7"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "EPL-1.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.aspectj/aspectjweaver@1.9.5?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.aspectj/aspectjweaver@1.9.5?type=jar"
+    },
+    {
+      "publisher": "Spring IO",
+      "group": "org.springframework",
+      "name": "spring-orm",
+      "version": "5.2.2.RELEASE",
+      "description": "Spring Object/Relational Mapping",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "13522279ca6ff43031f6072e4934e73f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "1b17c9e69d92e54439a092d6943e956f80392f43"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c689864bd2199eec734f8877eb25b6c686fe8ea2afa2f21231651f9c515d1d62"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "ffe5c6eafce183ab5500e461587dc9efa36396505390bbc75c9f3ed6b9fa70198c8939ce6c366b338509559e1d553a7ccdf1773930e02eab593329af38a95239"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "70a70ee98bec726ab3c26c58c9f12a0eed404126e52fa670ce93cf650337e26f521036540d423638af5ae0487b0e902d"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "3b481e4fbcd276ea2fe7ce7e709e8f7ca1c218e533ad7d2d77a7c2eba5e4d3ad9a8def5bd2b2814639899d0a64ee954b"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "cea5f6e64de5124476525fdd015c485a35a44512ab20152ee9176d18d18bc5ee"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "d72ab4daf93a62c47f4d9f2621baa99aa3bcaa493f2c39f0e7c2ffa8e67b63c020a9fa7a3123946ee4d10d4bfdbce4a954c5d52a60818f22d8e4f3386a5ca2bb"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework/spring-orm@5.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework/spring-orm@5.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "jsonwebtoken.io",
+      "group": "io.jsonwebtoken",
+      "name": "jjwt-api",
+      "version": "0.11.1",
+      "description": "JSON Web Token support for the JVM and Android",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "efcf52096d048e9bce652f2539a40f2e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "4a94011bfb3021579c93274fa12533b17b9326c0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "47e5b5d7996f5d5617997bd80f93ae217b1e640ef41deddddcd8612c749c739b"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "467946b4cefa36982007525f9e107ff472245d6234eff1f4c8482c73ea996a803d30aca3d8d8009918fc3350cf06a15486550473a9db00b8e1b8a07fcc6350eb"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "eea462f89df601a11b4ab7d62cb35dbec74611e452f4fe09e43061abae54f74c08389dc341a5d9de574f98acd4d69035"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "913b2807ae053396aa78b7e3b560ca2d61cf78a53c8ed979e58924e5dc883fc890f53fee14aae9c1c9c20ac6e04741fa"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "9a475402f21b871f8c3527bd963e5e3a0c0892c1a9fb3a582152d2b6d71a3eb4"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "99842f7932a65da831c19e3474128287832e569db0771503cf7a1613e8c3c4e12832127835dc6d2a37199994f5b786f91a6b8140c8cc6b5a0cfdd1325e715236"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.jsonwebtoken/jjwt-api@0.11.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/io.jsonwebtoken/jjwt-api@0.11.1?type=jar"
+    },
+    {
+      "publisher": "jsonwebtoken.io",
+      "group": "io.jsonwebtoken",
+      "name": "jjwt-impl",
+      "version": "0.11.1",
+      "description": "JSON Web Token support for the JVM and Android",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ba41695835f1a28760e07ae847a07209"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "eb75cfae1584487e95aa30ce4d7eccaaba9a3b00"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bcc7be8c93ace868d3e6f3c8d37602aa5629a73b67cdc9671a96267f28b368a4"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "5664c8eb2231257576393de14b78cab5054e6e386311ecbc9c70798952e947a1f814300cfa2b50a48ae2cac4abfc21b04eeb737d172a128cf43a150c2e5837c2"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "79334fa590f4238e92ec29ef65ad3cfac29e2eb8523354b669db0a2854d220c29a3469e9dd40206dd6a7590d508c44c3"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "35a4f8d994cbb99d46c653bf839c65892a7fdae985c1dae90abd753883a2ad3ae6a138007804db753f5b3e00c7dcee72"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "0556142fec9dccc7abe993ddbabdfe003fa062f3d98f90257d1b83a9d9243d09"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "923ae54e6940fe7f733f6f4f0f00dd2328ebc3d5a9a7316e77b8e88941935afaad02835fa207b177788a45cf7c933080de06eaf8f43efeb76495f92d15f5d739"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.jsonwebtoken/jjwt-impl@0.11.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/io.jsonwebtoken/jjwt-impl@0.11.1?type=jar"
+    },
+    {
+      "publisher": "jsonwebtoken.io",
+      "group": "io.jsonwebtoken",
+      "name": "jjwt-jackson",
+      "version": "0.11.1",
+      "description": "JSON Web Token support for the JVM and Android",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "0828a1642b1cf75539ccf1eb9fc8e022"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "7ada66a6c6e3e8f23654c3f57589150ba17a65db"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "29cd28683ea32bd0fb7c717e69bb2ec383baf3a67423e0f0af341d6622b1d961"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "b4a2931799dd09f2f953272489f577e53f026e8d25d164659c9c88351027cd8c3ccd503c061cc2b94f698f40b63d620116c33965f836a4cc07ae334a3920afa4"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "8827c0bdcd50d175d9bbadb3c667881c3fea48a0294583ed37847c550412fde15543aa082abc6daa7200dff71501014e"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "d11d6ea00411d48658057d249acbf65b65b4a337bfa827c5ea4b22c3c1ecd5020f8b72e3f43f85ef6148151a8684c7f6"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "e14d48146fa07a2e0ed59e4b6c80d5e652babfd31993d5a61d49928b6e146217"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "55cc381575bcd1d659c23f58b87f4176cf864669ef7172b6ad6c2d4854b5619b9b6030ab10ec532de12edac35b05aba69f5bdefb9e9e2b634188cb1102ec0ce8"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.jsonwebtoken/jjwt-jackson@0.11.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/io.jsonwebtoken/jjwt-jackson@0.11.1?type=jar"
+    },
+    {
+      "publisher": "The Jaxen Project",
+      "group": "jaxen",
+      "name": "jaxen",
+      "version": "1.2.0",
+      "description": "Jaxen is a universal XPath engine for Java.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c32cf69356254b8f5050fce6e86358e9"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c10535a925bd35129a4329bc75065cc6b5293f2c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "70feef9dd75ad064def05a3ce8975aeba515ee7d1be146d12199c8828a64174c"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "cad582fc12d0741e9e6fd7e0cf80a50feb04f5ef42043df96f8a5b78476c77695d8b43836d2241f76b35676ea759921edd25eaeb2c04ec916eb138aa2901ce5f"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "8932691b6f88cc0f78a18a995200606713a5a58bcdf1573c78ba856425ce9aed550b90658e1f9a0b13763f2468f7dadf"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "d30c46f10a2e96e013cacc56872ffca2a288b989533efdbc7615a96116772a1916bdc852fcff218b1152c5c5015443ea"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "196e11eba7bfc4955199ba1aec182677ea17b9eba92979001f03fee6abc6f57f"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "518fe8a795a5de2beb6a54622861abe183cf53cb332de2ac93f24d86153d0b03f8c08fb69790199e00973436dd51c2c0c5a362562c9959130f05f7e1818c74f8"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD License 2.0",
+            "url": "https://raw.githubusercontent.com/jaxen-xpath/jaxen/master/LICENSE.txt"
+          }
+        }
+      ],
+      "purl": "pkg:maven/jaxen/jaxen@1.2.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/jaxen/jaxen@1.2.0?type=jar"
+    },
+    {
+      "publisher": "JDOM",
+      "group": "org.jdom",
+      "name": "jdom2",
+      "version": "2.0.6",
+      "description": "A complete, Java-based solution for accessing, manipulating, and outputting XML data",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "86a30c9b1ddc08ca155747890db423b7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6f14738ec2e9dd0011e343717fa624a10f8aab64"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1345f11ba606d15603d6740551a8c21947c0215640770ec67271fe78bea97cf5"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "315791dc16bc6240d81da7fee9ae325102ff7db19a57805335d189bc747abc4d1c80144589ebf956613b93b2263c7565fdf171aca0c6c598616eb3f0bdf4cc58"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "6240f6747c788c1d512aa1383ff5648dc1c528504010d1dea0667cfa7b291e5521ad70521a8753e52c057edbdc190d36"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "5905840ddfa1bdad2bf8cc3b61a0509c438de94585473b5e4a4dccd8c653fe0a97b094b6703b502605b1141ad6b83d23"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "e46ea1f3ddd97c9e6a5714ed0e4f981962f4c11c28ec96f63edff801c202921a"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "4db8ae655765f69ffd94f4cfbf1d637a9159bb015af198902449ad0f9654b41aa3ec8695e36c358ce36ec7d3ebb67feafd955be6eefdb5d72f308e95a97ab8a9"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Similar to Apache License but with the acknowledgment clause removed",
+            "url": "https://raw.github.com/hunterhacker/jdom/master/LICENSE.txt"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.jdom/jdom2@2.0.6?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.jdom/jdom2@2.0.6?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "commons-io",
+      "name": "commons-io",
+      "version": "2.6",
+      "description": "The Apache Commons IO library contains utility classes, stream implementations, file filters, file comparators, endian transformation classes, and much more.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "467c2a1f64319c99b5faf03fc78572af"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "815893df5f31da2ece4040fe0a12fd44b577afaf"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f877d304660ac2a142f3865badfc971dec7ed73c747c7f8d5d2f5139ca736513"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "4de22e2a50711f756a5542474395d8619dca0a8be0407b722605005a1167f8c306bc5eef7f0b8252f5508c817c1ceb759171e4e18d4eb9697dfdd809ac39673f"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "1efcb8c663fff4cf7f2bc86e1a367b5f88819a6a2f80341fd5d41ad82eb0adda9f34a05c20115f461bee64d1ab487e3c"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "47f8067345da2e60493ced8f5852b5a9ee5fd1ee141c03177f132f97fa4beccd3c3f649276cbcb06a3fa2d0b39e20369"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "12e088d6b2f63a97e29d4cf1a81dbe311a0110e784677698a2eaa0b63785dc6e"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "82e8aa5fb7b8801b94c83f912dc863ff1b569a281081d33ca7e512a694202aebb60101b54bc9ba0a3b6a769221667a3d222b67102377d554603678798ca22d07"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/commons-io/commons-io@2.6?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/commons-io/commons-io@2.6?type=jar"
+    },
+    {
+      "publisher": "Apache Software Foundation",
+      "group": "org.codehaus.groovy",
+      "name": "groovy-all",
+      "version": "2.4.15",
+      "description": "Groovy: A powerful, dynamic language for the JVM",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "9c857ec7544a0324b25186fdb65bb71b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "423a17aeb2f64bc6f76e8e44265a548bec80fd42"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "51d6c4e71782e85674239189499854359d380fb75e1a703756e3aaa5b98a5af0"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "fc30f48e1d64959be90cd25c4e68e44aa3a9d80d319323a291f2655c65036d860525f55ed902ad0e5cdc114143d20a165876e80dfe949e5c9ad4d8a0ad7f39e7"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "b5a465a2e3038130af5f4350733ec938bf0d2aa3b0849b6a3466a11b87f7376be647201383b2b0a475a12afdda24c854"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "22ef9e5cdff87ad2f55c27f2ecedec06df116fa6554a4289fad3aabe2678cf042279346bd420c8b652fb45c79b64e9ec"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "dad59214f6bf37abfc7fac1b0fd431d2b74c7babab6f4e6c91818f09ee4a2bb8"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "6f216bb135b0f10632a650219dc99c29f6e5c6cada3625885067a551dafed05df5d11d536b373881b7ca2044fbd9de74d663a27288a47a973b9442366c5f20a4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.codehaus.groovy/groovy-all@2.4.15?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.codehaus.groovy/groovy-all@2.4.15?type=jar"
+    },
+    {
+      "publisher": "Jasig",
+      "group": "org.jasig.cas.client",
+      "name": "cas-client-core",
+      "version": "3.4.1",
+      "description": "Jasig CAS Client for Java is the integration point for applications that want to speak with a CAS server, either via the CAS 1.0 or CAS 2.0 protocol.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "0cde05fb6892018f19913eb6f3081758"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a000397061c6c02fd695c706430ccbf439843008"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "840a860da8e1cd65bb2b66c38222518e87158edfe8c3dc5a94f6e1183511c445"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "ec5a0eb867d986b53df55aaacef45e2a18afbb9806c3f05f93ccd5f36df87b4cd596da73b2d210762cf42fb923d3b2809cc91ae2de360e44e78364bfbd8453fa"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "77012985206717901cb47c5963efc7b920bd92dc80626ba7b38abb3d68a2551a5f825445f5f9aa528c86b955bacb0033"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "1f565fe3d094ad42f28a5272f46ee8633c952aa67c51e761d7350453a569982ba5da3c7181113896dbf49f8a7ee1014f"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "914506b15bbc7420e3822c4b5d2a3bef59137a3d085cc6c9ca4d5ff44201a1e2"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "2e5045c0cc2c400db7392c907055101505184f8977cb1ab07c17d04d572e47218d8fd3806d91ce5a3e01c114c83ef4c69bc90c8b1c3b2068a314eee5609a45a8"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.jasig.cas.client/cas-client-core@3.4.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.jasig.cas.client/cas-client-core@3.4.1?type=jar"
+    },
+    {
+      "publisher": "Jasig",
+      "group": "org.jasig.cas.client",
+      "name": "cas-client-support-saml",
+      "version": "3.4.1",
+      "description": "Jasig CAS Client for Java is the integration point for applications that want to speak with a CAS server, either via the CAS 1.0 or CAS 2.0 protocol.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "55dc427eb704e0676dac225a0f6bfa2d"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "7d27d726aad122dcfa55ac83573e588ff27fb02f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "93472e478414a5a5e5d0c6d8d758e158b43a58119d9d6bd8e752eaedd940284b"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "a78c2f1c91a372d71ae1e998db0bf2870d364823d983fbd248df4ba021cd30d6c63e51a59907779786d513e26406c0568dea36c541c58b83bf5ed03f99e694ca"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "2e1b8750ea4482d32bb30d7c3f91db14d3aa078b7d28010edb4da5ac07074ac49c791fe96d19e4b4ec937ae3b8ebc9e5"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "18d4222b0b32fe0578f82fa003c51134155d5c320be16e7b5ff0adddb87200f7db40545560630908e0d4be6ff27df88d"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "53f0d9dc10f38fc07d344849019eba8524d56594db40e0f1a453098530004d82"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "2cbbf89b63ba88224b2742c44c3357b4a444b56e61c60c1b947a8f146e2d69a81530aebb47060f00759f689a80280bcd90ccfe1c45fabcd00400d325d10b6b1c"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.jasig.cas.client/cas-client-support-saml@3.4.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.jasig.cas.client/cas-client-support-saml@3.4.1?type=jar"
+    },
+    {
+      "publisher": "Joda.org",
+      "group": "joda-time",
+      "name": "joda-time",
+      "version": "2.7",
+      "description": "Date and time library to replace JDK date handling",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "4f29e832878694d7096249c5c32f8fe9"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5599707a3eaad13e889f691b3af78c8c03842195"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f0f5720b333cd62b2b4f6164b1a0cde0a582f497798e8eea033f5d25f9d6f590"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "0b23fe06b6364d8aac83e0bec608b6d58dc6709c0d5e2a280426127bae110bfd9ddd28316d69fd206a063bfa60bf88b430d0341dbac06ff75c0cf0b39e49fbee"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "de7e1d6fc079dda84790e79868c1855c503dfda8ca68ef16632f1c5195b8006e84a518675aebf37d927dd430be90b004"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "6a13a1fabba1de72a4a48aa75a7ae7309e2f31981b3435e5f2161c3dc3020deba8793595ae37652d774f6a13d945471f"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "db4384ae0c39b8ec7a99043c4953cc0fe495b0472f745fa814c8ff3118704942"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "0e4fbdd52a532928027f61558ba0fc537c0e89e299f17416fc31f92b2ca3cdb5c06614d2deb916e6e874078470cf03be9c313ee723d617f28070f0fa65e02b48"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/joda-time/joda-time@2.7?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/joda-time/joda-time@2.7?type=jar"
+    },
+    {
+      "publisher": "Zaxxer.com",
+      "group": "com.zaxxer",
+      "name": "HikariCP",
+      "version": "2.6.1",
+      "description": "Ultimate JDBC Connection Pool",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2c8a1597d7d62ad2d0183a59abce577d"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6e63c6ac5fb7c670af831e483bbee47352c6109a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "52da9e85e82b296c0b25985f1acf6e063b026a78bdad01faa164141d96c0ec36"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "4b05bccb991bc9f33f50914ca25735c817668bf45e02309052ec4c0ad7c5286ca9f476128fdf3e25874bdfd599c53ea58af988a1e5947d5ecbc56ea3701f2c2f"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "9a3ad48fbb175dddfb22db4c5e1b412c58017361e96d4b3bab0816500db2fcbb91e1d05452745b467502734252ce1338"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "603145739c9cd990b2443583ed40b182f2d99a9740d9e0de4ba0d3ba2d2d3b2ab5700c53b25bec80b3a8cc756966b581"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "55dbc0a06160a2ba304ad2791e753bf5ea91f602a3aa0a634a40695ca932932e"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "a491d723e3b2690594ba2e5852ef7d2c64118ec9df39507936cbc0aa17e10606288cf5fd994a5cc5e43685f5dc999246230144e8d79a234035d6a20e7602ce4f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.zaxxer/HikariCP@2.6.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.zaxxer/HikariCP@2.6.1?type=jar"
+    },
+    {
+      "publisher": "JUnit",
+      "group": "junit",
+      "name": "junit",
+      "version": "4.12",
+      "description": "JUnit is a unit testing framework for Java, created by Erich Gamma and Kent Beck.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "5b38c40c97fbd0adee29f91e60405584"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "2973d150c0dc1fefe998f834810d68f278ea58ec"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "5974670c3d178a12da5929ba5dd9b4f5ff461bdc1b92618c2c36d53e88650df7adbf3c1684017bb082b477cb8f40f15dcf7526f06f06183f93118ba9ebeaccce"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "e2f0c2db405e282d0f84a1766b9e8d9736d4377e292a5ef8457aec10384f9077005865167025b2779634d75bcb4d62cd"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "a24a1d6d5ffe2f9fc3a90a442c3d1d5a12ae7bda3c68996c3b50f00186a2f961808c5ef504a771e9d6ab95ee38a383f0"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "02b1f076652120813646a0cb34350f0c73a3299b221567e089f6aaadf8ab444a"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "9e8f7057647c11564178e4569cf4f5682d3688b49d81acc60fd301f61053932ee9ac109c19cb639f7710d23afc76cb106ebde0f8143e2fe5fa08605201720a8b"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "EPL-1.0",
+            "url": "http://www.eclipse.org/legal/epl-v10.html"
+          }
+        }
+      ],
+      "purl": "pkg:maven/junit/junit@4.12?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/junit/junit@4.12?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.hamcrest",
+      "name": "hamcrest-core",
+      "version": "1.3",
+      "description": "",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6393363b47ddcbba82321110c3e07519"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "42a25dc3219429f0e5d060061f71acb49bf010a0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "e237ae735aac4fa5a7253ec693191f42ef7ddce384c11d29fbf605981c0be077d086757409acad53cb5b9e53d86a07cc428d459ff0f5b00d32a8cbbca390be49"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "4b5297d2a12cc32b824153afc83f1ba9f1869ca288330f0a2f759659d09e4c420eb6ba4a1efbfa0657b625edd41293d5"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "b14d34985c0a78cf0ba19b5a18bffd403e08adcb2afde228ddef6e16121c7046dbebf58c04d3419311c4496c48aa93be"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "f679af77deedf69b3c3066f7916583848c6fd32a950f9c0b0e2ef1da121717ba"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "bca821931e438a1977b7b4356b5f8cebf485634f82159d505c48267c34e6a0f4fde9c2917331365f66dc0e52e2ca3a2db5256863584110c27ecebefc28741f63"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/org.hamcrest/hamcrest-core@1.3?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.hamcrest/hamcrest-core@1.3?type=jar"
+    },
+    {
+      "publisher": "QOS.ch",
+      "group": "org.slf4j",
+      "name": "slf4j-api",
+      "version": "1.7.25",
+      "description": "The slf4j API",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "caafe376afb7086dcbee79f780394ca3"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "da76ca59f6a57ee3102f8f9bd9cee742973efa8a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "18c4a0095d5c1da6b817592e767bb23d29dd2f560ad74df75ff3961dbde25b79"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "5dd6271fd5b34579d8e66271bab75c89baca8b2ebeaa9966de391284bd08f2d720083c6e0e1edda106ecf8a04e9a32116de6873f0f88c19c049c0fe27e5d820b"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "f2791380e87fccb18519efd016c03be11206984f4765586d348e57e2f33756b21ed51a95fa09679e1473a5bf5d2d76e1"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "d621071a8bca1a32ac3603a816721fd93180a29e520d16a1c655686b169605f679818d6acc0000470ebe25265bdc9962"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "abb590301fbb93baf4f7afe227f230ee7992d9a56f7034ef2c37447ac8c52a9b"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "c025c503db0d09d0d435c1c96f0e7165f08375abc58eb4e4bf52b0b4689801019a7e966fa5372c03b0697083a992a0baceb7ab5d18659d262f5db4c9bca26584"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+    },
+    {
+      "publisher": "GlassFish Community",
+      "group": "javax.servlet",
+      "name": "javax.servlet-api",
+      "version": "3.1.0",
+      "description": "Java.net - The Source for Java Technology Collaboration",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "79de69e9f5ed8c7fcb8342585732bbf7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "3cd63d075497751784b2fa84be59432f4905bf7c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "af456b2dd41c4e82cf54f3e743bc678973d9fe35bd4d3071fa05c7e5333b8482"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "32f7e3565c6cdf3d9a562f8fd597fe5059af0cf6b05b772a144a74bbc95927ac275eb38374538ec1c72adcce4c8e1e2c9f774a7b545db56b8085af0065e4a1e5"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "8bf960fd053ef6ad1c3535824311f676b9ad537678b85f855dd5d6d726e391f8a7be9c9c76a8ae3ce8bfe671c1e2c942"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "e8f3282c08ceeed02947a13e886a3d75a6ea63e4f869a0e0bcbcf622e7cbffc81ed7bc045e82820443b6572c897cc4cc"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "8acc3481503989e1a78ad619bcbdc005b616c13736522b52e5ae5d782e8a0216"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "ab5f85d424640ddcf6fc13a41d12ffdee0be9508cd4cdc581168b31cf7917323f6e0d984a0631068e0e01c098098fe0037d1c4176352fd89ba3a4da5d641ca3d"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/javax.servlet/javax.servlet-api@3.1.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/javax.servlet/javax.servlet-api@3.1.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "com.google.guava",
+      "name": "guava",
+      "version": "21.0",
+      "description": "Guava is a suite of core and expanded libraries that include utility classes, google's collections, io classes, and much much more. Guava has only one code dependency - javax.annotation, per the JSR-305 spec.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ddc91fd850fa6177c91aab5d4e4d1fa6"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "3a3d111be1be1b745edfa7d91678a12d7ed38709"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "972139718abc8a4893fa78cba8cf7b2c903f35c97aaf44fa3031b0669948b480"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "6730a5f8f6b0c1a8fe7ca5e5836056e1109ffc0be9a285796f829927a75a54485ac923e45896a6ee713a40e217c3cf7a5fed52f6a1ff21db57f908216d151a2a"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "4bbabef26e8911c07bc5a36776656dfc81fc3a34b6db36b023ef4ac4575d6b8ebbb55afea07087902466a025639ee7dc"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "433e06f4428cbb90be934a1719c9a19dd6d2c0e90a2855e4adc567eb218d23e5e5d444ef5fd46e1289d65c09cfb59d28"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "17e6d645de88ee09f518a59a95c7ca51d69f5d06003c6b4127b1e833d3170a61"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "228758b7d953bb4e836288f3e7c21721a33afb87c7c6bd8d83cb6bb95b89a7a52498532145af6a86e20d7c42052b73d539796e9e63a858b57d169cf50d675b34"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.google.guava/guava@21.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.google.guava/guava@21.0?type=jar"
+    },
+    {
+      "publisher": "spring.io",
+      "group": "org.springframework.security",
+      "name": "spring-security-crypto",
+      "version": "4.2.2.RELEASE",
+      "description": "spring-security-crypto",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "778150c2ad2b2b857819de08568d10b5"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "713ae22bcef55ae21ca1967d7cb217a1efab5dbf"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "21051eb56dc16338a4fe9b5d61a2cf8dff5d51087e8020ecd152ed9b0f2bdc51"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "79177be6d6c06179e5d61bc82401c460521ad2ed4f7d46083e9f1183343598b511b4e7bad3063ec791643df2cc286d389c4ea76fe3caa8646e69e6cc636040e3"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "4157a40f11f0370e481988966777262be05b2227b5dbeb4ef2f75957813cb3dd5160eed2f981d64483a4e3129719354d"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "1f11ebbc5d5a6073f219259db886597ba1ce0164c0338c2b95c05ea2e77d6b0345895dcb27a0be01da3546499f7b87bb"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "977b784308069e79e7a91595c279071708cc88fc373c34a3d984e767e23eb3eb"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "6c0390687c3b330b9c6ce30c3a2fab3eef6c1897d139e3c34440c7ced1e5abc49aae02065ec74308b69e04f0926c03cce7c31cc4c4421d28f3638e8ca891f914"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework.security/spring-security-crypto@4.2.2.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework.security/spring-security-crypto@4.2.2.RELEASE?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "org.apache.shiro",
+      "name": "shiro-core",
+      "version": "1.3.2",
+      "description": "Apache Shiro is a powerful and flexible open-source security framework that cleanly handles authentication, authorization, enterprise session management, single sign-on and cryptography services.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1c71224cdfa52fcba0a20b992195cf36"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "b5dede9d890f335998a8ebf479809fe365b927fc"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2d5f2658e691012b9e62c6061fd817a98518d03e6370ab2f370d274835ca3a8c"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "820b31393700e5bec6e49de1e5f7561b013684a1c7c9bc09575924495600510b63d193b081688aa7665ea3fed8deabe5ef006082219feed91a8aa29587a470e2"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "f55dd4be8bd9aad95c87d91103aa6a1b1ccd14810a3c4007042fcb35001c5ac8d3064fd047664853ae393db32b5b4201"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "745c314c897fa7af4e8463b8d475d36f940860678e4f95d49f5a85507c86519636a7369b06c35a6f03dca6c1eccebaef"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "d0ba6e6fc41f37353ac7a5c9d1463bc969e6922a581ee638e1d363a36ca48e30"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "cee6e1a5e3014de0396fb286803a8510d1646719c671a0e219fa89645158cd2c2d84ff2c15f0c47ad146b24b2ab8e7cb1fb06f95f6fc053f870bc32f25aa21fb"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.shiro/shiro-core@1.3.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.shiro/shiro-core@1.3.2?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "commons-beanutils",
+      "name": "commons-beanutils",
+      "version": "1.8.3",
+      "description": "BeanUtils provides an easy-to-use but flexible wrapper around reflection and introspection.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "b45be74134796c89db7126083129532f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "686ef3410bcf4ab8ce7fd0b899e832aaba5facf7"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e1407b81d8138fb9c1fc731b87b5e0068ddccabfbc65dee59cdb378a90c5e81a"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "d1bb5a1180ee42f741e9935273638f38487e94adfa4c783a8c3f2aa060cacd6d9701b944a2b16dcf151058f237a533c2fa99df489fd48631892103bb6e3cda1f"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "e882ac1cfd9ecb13f00cd809da9d69e7a97f6bb4bd16621687001b69939a410ac684ae12f28b3ce21f448409fdd8a136"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "1822d6a58e3358e3ec712f0f463e2d3827a67b00b804910b271f8cdd55389fe566e1fd1e8a9a638b3c4acce5c1132320"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "ba391778936c6d68959ed9ab125b1c2ead393ec6051eaf430e460cb37579ba0c"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "e42012d346c5ec17ac1fbbbedf59b9f7c3fca7bb465f33499cfa0de458085d9226a6d0f956a5d8de5febad8a98905d05d91041f9c4b62bcc1eaee6bb2b3d9066"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/commons-beanutils/commons-beanutils@1.8.3?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/commons-beanutils/commons-beanutils@1.8.3?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.ektorp",
+      "name": "org.ektorp",
+      "version": "1.4.4",
+      "description": "a Java CouchDB persistence library",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d78fcd5ae13d1c09ee85839c3aa18e6c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d9587de0ee4816ace04f081cafbec41a3f1ffdd2"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c57e57078a53ea7315e56726c6d877b779a40a789df951b3f1ced16b15375986"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "1c70cf1fabd4ead4dd0ac7deaca104c535e1b13c7a9682bec1d287cc8f7cce7a745c90509bc596535d43b7f5abefed0e9ac666ce1e7fded2f6a4b3597cb43e77"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "fed875d2f5e99823d7b2b17df447913349aa6910f413518ab86349340bc17ad3b4b1f77f1ec67909e6d430c0828e6d31"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "74c44a459e4d77ddfc22bd5768aca8b5a51bf82f49f35d9e99610925aab3bf74f10bdeecc7d069a80564c01e249f3fc3"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "135d5685b5869073156e34e13d10991d4f847a771b0ac4eddf364aa84bc491ff"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "1e41999169ee74b08b5da77ab833f09559a441f572484d45f61da9f633ee29a4f9410aa48a8e6552d8b36b2b427ee638c1fe77855af253e4227b8ec41cde4699"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.ektorp/org.ektorp@1.4.4?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.ektorp/org.ektorp@1.4.4?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "org.apache.httpcomponents",
+      "name": "httpclient",
+      "version": "4.3",
+      "description": "HttpComponents Client",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "79e127301ad70d887139226326ac2d9e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "abe99a8183c7c154ba1fd0f4b6a3bd42ae67d115"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bf87a0559a9a506987a76cbc74818c72d50fefcb1472f47096460170863992cc"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "42f247a4432dac70313c6c4052b1645a65a2af3dff70fac4f6cbb2b88674d9ce176bcb5677127e958b9238f39ad34033dc4ff4d5a5ce2c945b447ba0ebe32bc6"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "f3c5f1836171de88edf3c7ed99d0c79cce131510195c5e5fa6baec72727c5ff221d4fd1ca54502689f66fefb0c5830e7"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "2b113eadfc47aa3b7f9dcaa06dc9683a7e155825853aae8e76915bfd1ebc63ec493782b89ac51051e66a13ebeade17d0"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "fe0377c8a04ee199a6722a1b201eb1e3e094d01d43a3432c0167fd3b5f148022"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "7d740048e5c2fddda187684e86bdd5757a9e09effc3206a03a9a5cb9b0de4edf8c449cfa08b083492f6ce1e6e1eac8932dcaa56d9a66f9b78e180615f1530a2a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-1.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.httpcomponents/httpclient@4.3?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.httpcomponents/httpclient@4.3?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "org.apache.httpcomponents",
+      "name": "httpcore",
+      "version": "4.3",
+      "description": "HttpComponents Core (blocking I/O)",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "4e4d81a276dec1ecdbfe0e5c98e4ecff"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "11393498b38e9695d0850cac26fde5613ae268b9"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ca6cce94277cca95ce5812e72a5ed24dd95a995788541be2c225a4a2e2bc5089"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "7baabd589a89c2c389d8510a649b9d680b76b9bf6e3deaeba4b6dfd8da8dc7f98b2f2963079d74e4aa5aae415f2b72781f13685f53d98ba7303dd38f3a219b0d"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "f2576be5c146b193e8748df568e336cf977472c1010b37eb6b6fffe8c4b2cc1e15c314369e29944e83f2d83bd10fc5fb"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "14d6ed1eb653645c5527f1bba403b18ea5e316f0e293fcf1f9b1328d38ac840c688c70caccc95d9d2324737673a87bc0"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "cd9a76d3211ce2336e0ce879d75cd0c7381051abebf2cb4ef1e061c18c736961"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "81780dd0a1a8523437b3b4c26249b0c336805c136fdc9c5ae615aae9a6ada23bb92d9b6ef27e0b558c3904299791978aa6f87cd25461062900d9a28313d7068a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-1.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.httpcomponents/httpcore@4.3?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.httpcomponents/httpcore@4.3?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "org.apache.httpcomponents",
+      "name": "httpclient-cache",
+      "version": "4.3",
+      "description": "HttpComponents HttpClient - Cache",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2f8d8a4d8ae72c15bf73e8dcf054a191"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "654889bc6d1a9682c44bb405ec4802db843e3e7c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "14f64796b74452c99a83b81b9111d5100c4389b2ca3a4676b19f0a5cebf2c781"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "fa9d4f9e980cb5bcac4324fdae8c059d167b658c392e12378ad68799a8f2ae0831e974edb7799a8a2c1d768a3943086a6f126bba2d66cba81157c4b85d8e4a62"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "0f9d4ebc5e0eb51c14f91ae85b4d5178213cecedbceee4843cac52cc743434e0346b7c49451fbbeabed847c17b95d91a"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "3927bff4361906dfeef0cc17360fc1849c9e90ed03aecbbd32053798d1b80e40dd744121adc1ef7badf8a80e7e5c0033"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "362ddd076a4c7d41d9cc2102e15d150f46f7bb1de6e5f6c9fc180d41573b16d0"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "a9c06dd94a224c6a731ad7d71b570406f95fcd4f81699dba828f05a6ab0acee1eec4d8bd50fcd5a8b9a4aa72adc53936ec2e86cc779be2af66b1dbafe519ef37"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-1.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.httpcomponents/httpclient-cache@4.3?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.httpcomponents/httpclient-cache@4.3?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "commons-io",
+      "name": "commons-io",
+      "version": "2.0.1",
+      "description": "Commons-IO contains utility classes, stream implementations, file filters, file comparators and endian classes.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "edb9481c6eee07f4feaa61502af855da"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "7ffdb02f95af1c1a208544e076cea5b8e66e731a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2a3f5a206480863aae9dff03f53c930c3add6912f8785498d59442c7ebb98c5c"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "def32668e72a8df114fa0919da66f25a3b5cac0cd36725de035727e13e9d67d98a786789cc41c97fbd6046465ead55497ad72dae901c541079d1d38cc16110ec"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "bf9d8993c078322f0f02d1bb622da41c57047d09b36b7fc50e171d3cc6fa85be21a176c6fc39ca0034b241bdd2832da4"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "4d5e9225c586f5bead8e643c7493d8e9e1578de88ce2cb2abe400a942fcd651af5e1cdfaecf800782143d7a10befb1c0"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "f157fdb5c4503f38f43b99d4140cf38b9a45b853cea3fe102334a22e7115e710"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "737af06069a41ff1d28a5b350c706d89167177ca5283d12d8364af3b80a32f7dbafaae2bb793221c1993f1005cf68eaf56385919548b6b3a5d0ac822b45954d1"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/commons-io/commons-io@2.0.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/commons-io/commons-io@2.0.1?type=jar"
+    },
+    {
+      "publisher": "FasterXML",
+      "group": "com.fasterxml.jackson.core",
+      "name": "jackson-annotations",
+      "version": "2.3.3",
+      "description": "Core annotations used for value types, used by Jackson data binding package.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f9c1a714fa130fa5cec7f478ee7a1f37"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "1248c5f768133f45da1691aae19bdc2dfd0b17b0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "653f6f6f291422749abbaed64711e10ea8eba5dd0b363330612831b8ff101ac7"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "27defd003445f178c9d7aa70a5348ed25024ffd9658ebb471e5738b5c6bfd90f82b9b3816f2617e85cd9d23c8d7f75af1aaeaf7254fa1d4fd97bfb2483c42b05"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "bbe97d2052eac343ea9a6fe3783cb7a3bb739f475236833a4ce96390db596f9fb14c1e97c69bf14eca93317f6ea9bee1"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "04142d64d44caaf80298167a3bfb7bc3fba2d78ff35257c7774ecf2bef7001418b19ed289f94a854b066c1a17885ead3"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "307678f3320ae0f5ecb03ed75a2833e6756c6f72671f6274b534d5155e8b7682"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "c292e3ab78a6241f16b4c09b54225ce37c7299d666a9606a13f3137fe73feed072311a107dc20b62ddc07d0b4ed0243ee2afb9398c5232621cd8133d01cec6cb"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "LGPL-2.1-only"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.3.3?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.3.3?type=jar"
+    },
+    {
+      "publisher": "FasterXML",
+      "group": "com.fasterxml.jackson.core",
+      "name": "jackson-core",
+      "version": "2.3.3",
+      "description": "Core Jackson abstractions, basic JSON streaming API implementation",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "4a21951fc31a1e3faa7941c56bdfea0f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "7d8c5d79cc99995e21e6f955857312d8409f02a1"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "11c9651fd29f0bd87b0014fc3ae18d1157c1d69f1a3b90c97ecb7a179d5d7450"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "af766f96cfc770b325618ff82a518f25aa5a78e4a746d43826ba760a9232fc967e26ecd209319c5f46a27284e2ebda933a4a6187ac3c113be2cfd75f0a142e83"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "96bd06ea56fac7783851d6dc4a5f967855da397405cbf516bacbf551fc024cf2229fe203e2c674a790941a1ad6680771"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "d9f210ae498a07ad4f4161e9c807e5ffe5637540bbe7e0a1979579a20110fc68c5d9432a6f39f972b6f8950b67d4119e"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "68177ec795a7035696390fafc5fed085ecbb8fae361753ae9a40f508dd61a8f8"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "7a68f6ad98b7a5228a89756626d548837c7d6b5ee9041dc4e2b79579c18bc576f70da8b82d676ef9e035d3ae89a5894ed13b2a6d015fc622c5ba9c01e946f259"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "LGPL-2.1-only"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.3.3?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.3.3?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "net.sourceforge.findbugs",
+      "name": "annotations",
+      "version": "1.3.2",
+      "description": "Annotation supports the FindBugs tool",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6c0ecce1632670df9d2bb5dd76719d90"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d77bc83e0408680034a29481a89de0dba9802a97"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "84d37d4262be73c2c3f44be2c376737d77572f40435537215f3dd0a02a810259"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "c9d00c49f91677f7e7b5e6a615992f31c18e39e59fdadc82735299ff5d42065fd443e3d85422c688226fe49cd11f26f4eb527ab531bf2b59a121f516902e4f52"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "c681cde730451b141b7388c70ef0c5ec829c01ae6cb9e18897d3ba280626f8ecd3aaceea24f9196c840b63ffa0fc3513"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "b609ebc8b5d74324ec51ca45c3a79d759e1eff38efe0670a1dcd44381b83134f3e7c8f83ce68fe441ade79840065efc5"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "8e4a5c8f1503238b4d99a61821ef24d16b5450c2d0f9dab4c29378a50b5c7f7b"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "19b40eb937288a61db2e65edc0b1d5d86e845664eb85f9ce9a7c29bd5198c3f8a059e0ad12d30a4b44b4b274769b4b8f2259e0f73213cc94bbbf02d36e06d261"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "GNU Lesser Public License",
+            "url": "http://www.gnu.org/licenses/lgpl.html"
+          }
+        }
+      ],
+      "purl": "pkg:maven/net.sourceforge.findbugs/annotations@1.3.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/net.sourceforge.findbugs/annotations@1.3.2?type=jar"
+    },
+    {
+      "publisher": "FasterXML",
+      "group": "com.fasterxml.jackson.core",
+      "name": "jackson-databind",
+      "version": "2.3.3",
+      "description": "General data-binding functionality for Jackson: works on core streaming API",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "047bdee85e04e09e06bc558c8768bae2"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "63b77400b5f1cf83a81823562c48d3120ef5518e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "46b5cdab6f8d6aad830ead3acafc9cd4970bd0054d12a4d9b5f4eb6efa70cf4a"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "10e80b4fbe06d1e66b2da74dfeb39611e283b71e623831869eb98fae2adac676d0b527cd6d845720720d1fe3cb7d62fd273319965c8fbbab4fbd2e2f0672c7ab"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "65f65679c604ce7017f7d2bba3be1ccd79679e4aa0b366fe2ef13b0cd0fef2f6b7a4c65403a837625084321cf757739e"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "ad6a76a21a0ff6c686745e2dcd8f9e9da1ed80cb809d656ad4b03d80a73579cf6dd68bb2e98e03df5d06d8c7e824108d"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "044fac315fea27b98fd6bb39f0a03f6c81791b9af21379141f021baeb4a26729"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "f5a1af146b48cbbc2132172f9e3489585c6cebcb5208dfd18212d946ace44395f1e657b4d3ef09188f1dc200f1e1a1f8fc80bb8010164b37245352a55ef43714"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "LGPL-2.1-only"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.3.3?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.3.3?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "com.google.appengine",
+      "name": "appengine-api-1.0-sdk",
+      "version": "1.9.50",
+      "description": "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "55c8abb402d18b6b9c6c45fe055e9b1e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6b372a4c7037d14a33c952d4027595bb02891c71"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d9a3903a69916177bef7fb0be7f4c254a7a2a1358f2bc6336d8132a6210b3cb3"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "b81a8175d6b96913149d2f71cc1716fa94066f927e818ce0e2e1a2d0fc3e3e99b367460cd5e8c795bcba84f33b0d40db2cb7fe26413f9f852e4b4eabe8de8e0a"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "ab5897761ebaf391acd257203d89e28d1e832f1ee2ca19032a6ec7fbb64c709ba09f490610d01136fed17c941704f674"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "582cee7b6b5e3757e94b509b6645306e142cdb3114d3173d47ab99a525d7f57d4f5bde94d099c0b8b08c4dab8550732f"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "cc632a0e284bf4f96b620bd957730274d446aa20cfa9f0528e0ffb3e4825bfcc"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "67cb28c648374b3066758cf481437996d29cad6061760e736c51c72e25a2299bc2b6268c3051e33b7923bb686d70e391d86985033d391bb4631a103c407cac47"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Google App Engine Terms of Service",
+            "url": "http://code.google.com/appengine/terms.html"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.google.appengine/appengine-api-1.0-sdk@1.9.50?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/com.google.appengine/appengine-api-1.0-sdk@1.9.50?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "com.google.appengine",
+      "name": "appengine-jsr107cache",
+      "version": "1.9.50",
+      "description": "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c4095cccc4f8123e36c50a352cf70549"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "57b09bb6c12004940302cf23545c31aa4624b7f0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "994f791c0681df817bde6a14794981e638e07a3d7e79e3eac9e37ae95b8ab7d7"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "a37c9c15dadfa401ea16123fa5c31ecc7391f971fee9975535a9a0f254eac4a3f2f9f919bb956a4607c46f3fcb32bed90c484699eed6a0fc2eb6822b119ebd6a"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "8eb09bbb7b9b7271285152be717ef2c96f133390c73fb05226df63c0878fbca488b7c1f335ab536ff219e1ffd596665d"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "0c5dfdb6832f136142055b92133fad907074b7ae7a3bfd24f90fed7ad15fafa8d63ffeb1711daeefc4da53c2b344bca3"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "ab49cc841d0aabe8a36d4a45ccb40155bcd2d33341df0c5d980932b6212bddcc"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "31dbfdad5c4fb04ed03a987ebaa09059a8420784b1753ce4bcd1fc2ee88523e1c9c58547040ff01f4375a963af3a739db26b6618d1c4f855ce64ac6fef5ab4aa"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Google App Engine Terms of Service",
+            "url": "http://code.google.com/appengine/terms.html"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.google.appengine/appengine-jsr107cache@1.9.50?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/com.google.appengine/appengine-jsr107cache@1.9.50?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "net.sf.jsr107cache",
+      "name": "jsr107cache",
+      "version": "1.1",
+      "description": "",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "4131dca0c136ccf1128adde156a8a3e0"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "193a0dca92c221ebf45c7181f00e5db967721c08"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bfeca727dbdb8810e2c84c6dc861502bd08898d037e011a2498bd8aaad6bd35e"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "efcf2ccbb690a34822df00467f88bf406a9e59eff104d6a15d313c32778d4f586af679adda2118660b8ff5a5f6913667c467842784084c21e5a11de562ab11f9"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "77dcab0413f9290a17c1c412cc47d1c5216eed664629096eb2037d7592a03a0f98764ad3cc484c234b090fcd4c07bfc3"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "a9de9d1ecdef68123b3187ec6891065ae8380acf00c0a0bbff920e39d4733c452e8728c905fcee011a3d981d1af1a67b"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "c999c4b0d26bd2699d807dcb40960c3ee9e24d73b8b6a2978a0ac2fae5a21b98"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "6838a782e87dce0c161b3d844f15db17ce4beee6bc4cd315dfc1a82cf6fb92a93d51fa9a067dbe6c686444f8164a3d9ce71df33c5f6322775abb7d9ac7647007"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/net.sf.jsr107cache/jsr107cache@1.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/net.sf.jsr107cache/jsr107cache@1.1?type=jar"
+    },
+    {
+      "publisher": "Chemouni Uriel",
+      "group": "net.minidev",
+      "name": "json-smart",
+      "version": "2.3",
+      "description": "JSON (JavaScript Object Notation) is a lightweight data-interchange format. It is easy for humans to read and write. It is easy for machines to parse and generate. It is based on a subset of the JavaScript Programming Language, Standard ECMA-262 3rd Edition - December 1999. JSON is a text format that is completely language independent but uses conventions that are familiar to programmers of the C-family of languages, including C, C++, C#, Java, JavaScript, Perl, Python, and many others. These properties make JSON an ideal data-interchange language.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f2a921d4baaa7308de04eed4d8d72715"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "007396407491352ce4fa30de92efb158adb76b5b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "903f48c8aa4c3f6426440b8d32de89fa1dc23b1169abde25e4e1d068aa67708b"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "977ffe05c17965b403a60471eb6c160103263bbe454e942d67d4d725e1826b504de6c15038ff01ea90632bf9ad8a31b47c6662613bb905f020effa68c44d6f9a"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "d3d68802a0379f45570af1028ae1c9532c399a8fa9956328f59d305b62add017c77835b139d135c7719efa73725bce83"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "df77b3e0be05434220b670bc22654172a2c3e16255df25e6155201ed034509bdf6c1e2558f5289a83222f12958f48ba9"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "060cd75a81db1a152da28f9594c9efb5389ac624865a6a55c95d2a95b9bcd300"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "342532fc4634437855e8feb8a202e1112f179e38dd90cb07332e750db36d3fcbf5d7cbef48814a59de0cbf0ab07fa4b3489215022fd33036256effd4e0e7cc48"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/net.minidev/json-smart@2.3?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/net.minidev/json-smart@2.3?type=jar"
+    },
+    {
+      "publisher": "Chemouni Uriel",
+      "group": "net.minidev",
+      "name": "accessors-smart",
+      "version": "1.2",
+      "description": "Java reflect give poor performance on getter setter an constructor calls, accessors-smart use ASM to speed up those calls.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c28b871d258b4d347559d2eb7ecec4a3"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c592b500269bfde36096641b01238a8350f8aa31"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0c7c265d62fc007124dc32b91336e9c4272651d629bc5fa1a4e4e3bc758eb2e4"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "39fe6a5ebd2ae2d33d8737c8407a8caa4f6a62ce2057d726bb82496d35104b76f230bbb9721e1db5f535fefa3d70ee88c0a5a5e4a3f1266d7317cae897ad0882"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "fd66aeb9655bbac142a595d90457497b8fdd908c8d0f35c9b331ccc111e89ba863ebb4d9463b768426d6445b59f35f75"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "4059f02102576b7e8f2be849cb35ec77daf992d07d08642699c1ab9b84a51756edca181be90e84ae31eac83c9372da9e"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "e8f203c6aed8ca994ea94c8ae236e833e7af1b76e582b52dc726f8a86373b6aa"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "2ef69cdd1e807cd2ec1cb3b1af9a5a6ad6eec7e1c87270f971b0d69a1865f173412d3932ebc187397cdce767d4b0f2cc64660080461b93dacbf4209e43bf84c4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/net.minidev/accessors-smart@1.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/net.minidev/accessors-smart@1.2?type=jar"
+    },
+    {
+      "publisher": "ObjectWeb",
+      "group": "org.ow2.asm",
+      "name": "asm",
+      "version": "5.0.4",
+      "description": "A very small and fast Java bytecode manipulation framework",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c8a73cdfdf802ab0220c860d590d0f84"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0da08b8cce7bbf903602a25a3a163ae252435795"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "896618ed8ae62702521a78bc7be42b7c491a08e6920a15f89a3ecdec31e9a220"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "afee8f98ee21771f104318d95b839d9ea6ea083157bd62d8bc3462d9302dc20ea939d1b4ae2222f92f09b92bc9ab1317aff02734007f716cc805fe49b92a8a5a"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "84f68859e74fc5a1bbb32bad682b3554ba0b4177f1e152991defe37151bdc31c1378da2876fe995c19445ca793260170"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "e2208311fb6a0807a535d18f7053c66b006bad3ff47c0937b675131d667b243402f8a4ed79028f24482f4c2d542685a2"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "ad3bf09396094a4522742f61155d40953b7c0ff806942e827797a1bcab62a8cd"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "37ac38d0cbaf89113e53845fc73da643fec6a2a6a4a0c03106b7c3bf2c645744095762d9b20bcaf5b691c3d91175983ad8e915d40ce71cdb8feae0c2bce17fc8"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-4-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.ow2.asm/asm@5.0.4?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.ow2.asm/asm@5.0.4?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.bouncycastle",
+      "name": "bcprov-jdk15on",
+      "version": "1.56",
+      "description": "The Bouncy Castle Crypto package is a Java implementation of cryptographic algorithms. This jar contains JCE provider and lightweight API for the Bouncy Castle Cryptography APIs for JDK 1.5 to JDK 1.8.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "3c1bc7aaf3449308e34296546078d9f7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a153c6f9744a3e9dd6feab5e210e1c9861362ec7"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "963e1ee14f808ffb99897d848ddcdb28fa91ddda867eb18d303e82728f878349"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "47e5f73d2b66891cf21412b807481fff4b1a844ff247ba170e7bab25a7f6303cbd5ada22e7382ba20ee344d8cc3a1909a3d255f4b24defe9357523b4a122db68"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "c9de4efe55d8737d5c84e7253cabe2de7b7d72180ef4c0a645ede19f627d3ebce7c0c4f19e51412b7e0a16d6c6255d32"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "ef69f74fbf1f5416c90038f07aad6aa83e60932cf8a31400554e0380c134921ed8638528b4339edd5e8b7d1df4f62a3f"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "ab4e77030ace3c79f45602cf94baf81ae18305ae83037c5a37077a752cb5bfab"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "24ea4d76cc78baecafd8baeae0e201201463d920c102fe20f8dd29ff307785194dc27323215dd24680b77bbb1e65841f8150f047a3b8f007c9b04f4860b4a181"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Bouncy Castle Licence",
+            "url": "http://www.bouncycastle.org/licence.html"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.56?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.56?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.ldaptive",
+      "name": "ldaptive",
+      "version": "1.2.1",
+      "description": "Ldaptive API",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "83ceddf050335bb656d368cf23e92e49"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8226fe6e32d007affef2ed72c9a92d877780bf22"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e7aa61745ed580a335196fd9416c051def5aa4b059b1b7721c61049906197c64"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "3c70d07d5fa4ee8488e21c10291d8e3b715fd4b4cfca90ea7a123740831a98ff7e650ffa7da93bde484d9ecb829a98aa245089440e83fceb48dd171e366175ed"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "cb1e48a52b87f1afdcc114c13cc51ca36dd77ac206b393396d10d7e6faff47d1b649c91b419791b698b566413d745958"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "c31c4f9ddfc50d5bc2928d596347f785737e19d37e7534e20c166bddf1b0472bd6806aa1b15c226aed56c62984f0511e"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "eafce01bc874360551e0217e23edf3ffa97c96ac7e1d27e27b98d273895c0d66"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "e07d71d328955d8cabdda329d80a469c94ed9f45f14ab3d8027d13b4f3723b9f3e01f92d832f03e5ba9b1e65b8a9c655e886598525c7925e1ce55233716c0c50"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "name": "GNU Lesser General Public License",
+            "url": "http://www.gnu.org/licenses/lgpl-3.0.txt"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.ldaptive/ldaptive@1.2.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.ldaptive/ldaptive@1.2.1?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "commons-cli",
+      "name": "commons-cli",
+      "version": "1.3.1",
+      "description": "Apache Commons CLI provides a simple API for presenting, processing and validating a command line interface.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "8d5fa2a42fef17d9034b35a9ac9cc750"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "1303efbc4b181e5a58bf2e967dc156a3132b97c0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "3a2f057041aa6a8813f5b59b695f726c5e85014a703d208d7e1689098e92d8c0"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "383ff22040787d7a27e18b414892dd204ba0f9d75e43eee775c1276d6dd6ea2a38fc349edec1b2bd332fb0bd324dcc8ccce084b98d47bcaf8aa443773fabf3de"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "d0c5fe2acc826cec496790cb206fc8d887eef5a400bcf72cb81cb493688286045d8353dd1a7ed57f30b95bbdb4f829c3"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "9e1e44c060bb57dd6daaa300b9bdfeb4e977e770d113f85e6883a9c829e5309c90a557ff0b64cf32f5252a6ed0829a49"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "8c71796d10168b9f0c20844032b90c793f05e9bb581e6c072c0680f815d6d2e5"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "737381965fc1fb7b746ceeaf449f4f8c481793b1d43c2260be2ef94eb93d558f7399f0b82f367620cbd1ecedb64dd2b4da990e6dc63a54d2ef3a875ca00f7cbf"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/commons-cli/commons-cli@1.3.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/commons-cli/commons-cli@1.3.1?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.mongodb",
+      "name": "mongo-java-driver",
+      "version": "3.4.2",
+      "description": "The MongoDB Java Driver uber-artifact, containing mongodb-driver, mongodb-driver-core, and bson",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "69f16fd2a8b89c21482268768f4ae6c7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5d0448606f5f7f3974dbae69c4ccfffe214ae60d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4a5d72655beaefba6ba5cca07a4f3a652962598b860752ae8d39950e96a96ad0"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "54e1ba696445b68d58eeb5b2ca8b9b5d6020a0967f687bcf81484f43af758f9ddb841d8b6555c425373a6e0dce5429b1be847297b88c167c8df0a0f126d5e7db"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "6799e3c1baaa2bcbec840230bae7096e669013376ce5abe6dbfde7c0bae081794c2e807834293924ef84635320f100cf"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "4925c08e02c979d082ce73efb8bfc5495e2b0bd4a99cd015a6cc0e685ef45b96cf3de86ecb84df1be213897eca62cf48"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "88463e599311fb47785163df018d307b00c67894cc900c0a5bac65d98060d084"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "e18480f316998a7c6fc48b7095f197c798034409de3220d7722a367330b860e09721a0d1df6b929b2ab9500b48d6289e2aef036db509ffa9715e9f884a285de4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.mongodb/mongo-java-driver@3.4.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.mongodb/mongo-java-driver@3.4.2?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "com.github.scribejava",
+      "name": "scribejava-apis",
+      "version": "3.3.0",
+      "description": "The best OAuth library out there",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e6a98b0fdbbeca2d79a16e0dd69cc693"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c460fdda054a44139f0f6e1d927ef092dde36c17"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ca0210e37efbb0cfff25e2b8a71ca3be350c2901283979971617b866836305cf"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "62074c3136e7b7509e634381c25be1b93900db39eb3a1bc495edafaa6e3d0621dcbcc7a2a7a723398186822c1d71933e84d901c310f76595aac8ea7888738d57"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "9260d10d779d15e8a1756f3c903e409b79339550ea49d0380ee91550a82abfdb415440296cff3afcd5ab98cd6259b232"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "f98447ac2431ec693c59bff682611506cc29e7127e25193993a12038df0abc723938a0783862e41882020ef8e1997bf7"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "f57fdbdf9220e4cf81c3b3be28191d1bfdfb647c09d607431c4e90d54e611836"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "fcb2d7dc2b02e0bbe281cb2284c1ed0a19b63dfa8df6bc85732d1c2d00998acb970fe80c60552f475e343a7788c59bdb62853966027135a67a15f4f619e95ec5"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.github.scribejava/scribejava-apis@3.3.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.github.scribejava/scribejava-apis@3.3.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "com.github.scribejava",
+      "name": "scribejava-core",
+      "version": "3.3.0",
+      "description": "The best OAuth library out there",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "364e6139d59d2bb8a8cff65022958504"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "7a3394ee3f48e9cebdc89ffda6065171e5e52421"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "a344eec8ae3859e7793cd58478df44fe4345feb85cd59460b566fb8c0d8d2400"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "56f537722a2e5c09e2685662b7f600cc06a7900424c0c63711fc5ceab5ee9cde7b95b792b88f5dc0bbb2be69170482a83947c5d9f8906ef95c65dcad6f432e04"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "c895b41195ef5e60ce481ffc25ba8c0f64bfa9484ba33925b5f0f6bef89041b2dd855f304fe35eddcf867a19e7fa4714"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "df9c01b622653c52d14377ce8e8d960de7b6a51a283be42523ec0c53c285293a8bd12c21c5aa513fd79daf0463daceb2"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "0ea36283ad74aba67b47d888509e89e5b82e271e396c942d960558f82476922c"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "10c808c2881e207e05e6a75846cb02e459b62cb68e61b28ef4517c1431a9361a2ae5f631638acf1d055cd62052bbb1f0a9aec05c359e112a0348cc9b31edaf46"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.github.scribejava/scribejava-core@3.3.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.github.scribejava/scribejava-core@3.3.0?type=jar"
+    },
+    {
+      "publisher": "FasterXML",
+      "group": "com.fasterxml.jackson.core",
+      "name": "jackson-databind",
+      "version": "2.8.7",
+      "description": "General data-binding functionality for Jackson: works on core streaming API",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "fb6e31b050960abe2cdbcc7623fd21f5"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6c3257ef458ac58a8da69a6dca3d2a15286d88c8"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4f74337b6d18664be0f5b15c6664b17aa3972c9c175092328b139b894ff66f19"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "f4aeade7e72c71a54bbb9ee20fb16b69bd31bba28dab7b2c2b18cc6769175705b6e89c06d06b442e4eeee0c01d603500206d2b9eb1cf35eaf36eb245b2d6a32d"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "533c778ff6ce9c6eee19ae0aee10405977e63d41c3086895a5c9bfe9ab0ab42b5ab0e3bb5c5abe9320641c1964af7ad6"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "139c78340409d2b7aa42dd9ddd3ff6dd1a27625e71d1ec98a7f2b758eabdff874dfa18a0c71c521396f54bed1a48f86e"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "02a1b1963c01f06e33e7a03fea63b89534434e2731bf34b16522e4fdf8afaae2"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "eb4f326980e1b27e7cf17a66cfd25c28e3f791c4f51ed37c63b5077d04cfd962173b6334b732db477b0cdc863ce79b955d155feabf30915eebb0cc35ce63af60"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.7?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.7?type=jar"
+    },
+    {
+      "publisher": "FasterXML",
+      "group": "com.fasterxml.jackson.core",
+      "name": "jackson-annotations",
+      "version": "2.8.0",
+      "description": "Core annotations used for value types, used by Jackson data binding package.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "288e6537849f0c63e76409b515c4fbe4"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "45b426f7796b741035581a176744d91090e2e6fb"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e61b7343aceeb6ecda291d4ef133cd3e765f178c631c357ffd081abab7f15db8"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "9e549c2044bd9856c7cca491f6acbd0c5a87a208e550410cbc466669328f6022d1bd89258eca7c3a765c2427b0d33c83df29cb1205bce51a1f43b4148e1bfcac"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "936bfe80fea70d1672dbf18c1cf9f5b2fc7b60c43807dc66cbda1e3bd7596b2bb359ad9f331563da735a99d0b9d769c0"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "bc03f20e88c3c4557f68d16da87cf709db67fc876c1d128bb1febffd8614fec31a9ce8d2db227ea6000009066314c04f"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "04edc2bd35d2de0216c3dff3f034edbb3e7e90a9403074021be292057420f248"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "016388ec95e5d0ddb8503e12f64795b62c3085ca22467aa8d5ca2daa668dcea253f531c2fd010342c54b10df3fa4464a1c94cd82c5c93883f25ce1d705bc5e54"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.8.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.8.0?type=jar"
+    },
+    {
+      "publisher": "FasterXML",
+      "group": "com.fasterxml.jackson.core",
+      "name": "jackson-core",
+      "version": "2.8.7",
+      "description": "Core Jackson abstractions, basic JSON streaming API implementation",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "18507133d5fc96dee39186b6d44d148e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8b46f39c78476fb848c81a49fa807a9e9506dddd"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "256ff34118ab292d1b4f3ee4d2c3e5e5f0f609d8e07c57e8ad1f51c46d4fbb46"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "a1bd6c264b9ab07aad3d0f26b65757e35ff47904ab895bb7f997e3e1fd063129c177ad6f69876907b04ff8a43c6b1770a26f53a811633a29e66a5dce57194f64"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "30cc5bdf79922026205b4fa407ead61bff033489ede5996e1edacc848312af28bee27b7af8c3c7bbdf494789f0569548"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "641bc9a29e2c97f2c735941d31f02253f4ff9b5984c4677ff3b65f5a9d1c9c740f18dcf2a1f51910f1ca5fc937de897f"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "d00ba9a0a17953ff14f83e529c63e85f409132bc2951a6f057e5eec755bfc571"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "12a499f0dcad81b9f2eb1baade596ddeac0d14997fcad7bee8be62c4ce5c506e82dcaf1bffdce0ebc1560654e0dbfcd2574f768415dbea32ba1bc8bc01cd37c8"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.8.7?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.8.7?type=jar"
+    },
+    {
+      "publisher": "Connect2id Ltd.",
+      "group": "com.nimbusds",
+      "name": "oauth2-oidc-sdk",
+      "version": "5.24.2",
+      "description": "OAuth 2.0 SDK with OpenID Connection extensions for developing client and server applications.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "de7860656c2deec532c663a58346687d"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8e03e120ca350badbfa3487ac1ff293ec4994fde"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2dcf45ec6bb62b689156cdba8b9bddb5a8bd5bd7d02de3fe1dcb37316b691abc"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "593292ea90f6ac767d42602f8efd1e3f52b6dae2081afc505b49fdd5652924cce4fafee39000a6577a6a533136796520c7dfe547791526424fb4a90111301f94"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "6e4b36079c41602a6e120c963015976e7e7caefdbdbdeaf926d5c6b5085818d40094ddabfebe1c8132b9c0a13ad611be"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "9a34ebfc692473a212fc364b8fe3016665462a23b5666269915a2c2e443784bc804023dc3cccc579a0a2f91c301ec260"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "e5e5b81abdd3d4c72898338047738203a826a74b2d96face47e84f76cbe37f98"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "f709233c12c24c2d29ce2364147fe4a14d33b04b289f5646d0b01a4921626f9e514dea77ed91287d212682f9993dc255c95fba287d30193ec7d6f9b2d9d338b2"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.nimbusds/oauth2-oidc-sdk@5.24.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.nimbusds/oauth2-oidc-sdk@5.24.2?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "javax.mail",
+      "name": "mail",
+      "version": "1.4.7",
+      "description": "",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "77f53ff0c78ba43c4812ecc9f53e20f8"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9add058589d5d85adeb625859bf2c5eeaaedf12d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "78c33b4f7c7b60f4b680f2d2405b1f063d71929cf1a4fbc328888379f365fcfb"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "331d2ecda625f4ad8a2c2539b577e9906787e7ef08d47683f45dd6fff18e3b7601071f20970896210bd26498018aa570fe2ab4bfd7f7084068a234a809bbd481"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "9b2529ac136de86400b6eaa9eb887cdc3de3cd993131caf99ce808bc2ac208b01772018aa38d49ca0bd1bc962e08834a"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "4c86276795145265031b3ea63c097106df20076151c8a3a682a7092d68d91f243697286e3f543e8a1ef1e46ed4bb157e"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "eef5fbcc453d8f709bc49c5f3d4f02a7cd8437f62cab9eb6b5396713a2098973"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "c28159ba68a18d7d57428fcd75a9b019b3e79e573debbeef2859ba522309b9362552c861063a5ab541175bfb0ae69c08e5fa237f3ed3b05160de46e4fd2d8132"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/javax.mail/mail@1.4.7?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/javax.mail/mail@1.4.7?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "javax.activation",
+      "name": "activation",
+      "version": "1.1",
+      "description": "JavaBeans Activation Framework (JAF) is a standard extension to the Java platform that lets you take advantage of standard services to: determine the type of an arbitrary piece of data; encapsulate access to it; discover the operations available on it; and instantiate the appropriate bean to perform the operation(s).",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "8ae38e87cd4f86059c0294a8fe3e0b18"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e6cb541461c2834bdea3eb920f1884d1eb508b50"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2881c79c9d6ef01c58e62beea13e9d1ac8b8baa16f2fc198ad6e6776defdcdd3"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "c0ff5bf3ace7acc1b31fcc109cee48d9eb8f025ae15a31dc91eca760933bdb97c93f05d61e95af1e317859d72e5f179f897f5bf3df0e3810f4212d43bacee4bd"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "c4ee54d80a2e67e819700051d6cfa01a17631c89f942b8690afb601e491f02d7497fe57bd5c70edfb9b444ae8222b846"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "de0777d2d1d7aad105defb12aed17ef38abfe89db2449c5243fa3c69304ea24dd8df0881330351d0733313e8f7252814"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "5fb94d2742cc3d44abad42c5d61b9c7464a2ef33bc58b4b5b121d49799123460"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "c5e37fe3d9c420a9035f1160eb1d396e94f01851c01c6e2f19f19a221bfc484e63f9660c7377f58aa65246b95a9eb799ac4e6798c0b20f658edf00a4435e1efa"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "CDDL-1.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/javax.activation/activation@1.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/javax.activation/activation@1.1?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "com.github.stephenc.jcip",
+      "name": "jcip-annotations",
+      "version": "1.0-1",
+      "description": "A clean room implementation of the JCIP Annotations based entirely on the specification provided by the javadocs.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d62dbfa8789378457ada685e2f614846"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ef31541dd28ae2cefdd17c7ebf352d93e9058c63"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4fccff8382aafc589962c4edb262f6aa595e34f1e11e61057d1c6a96e8fc7323"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "02fcd16a30d0e68b3e9e4899731181c6abb7117baa15c096ca940e01dde08bb86101cbeae552c497f8a90d923b5fa2f2b6f3850baf8dc94dbd399887924a9069"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "88b0ecfde391a3d8468349c70e1539569768dfac3233dfe0b4660904df04e6c6bf26ed9c0784b9b22c122c3448e2a6b6"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "487b53f48b55b98a61ae60abedc43543887944867aa6bcb78d5ed46e2d0d7c19510c5fcadc362d939313feafdcfc55e1"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "3e79c8f58865d2d58a5311a8bb45772007f07e7f3ed2780784d1e4382dc934d0"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "ff32665e1b6d8176ccc7e8c836ca7343c2603dab053e42d79b4258d51a14ff63933c67d24034169ac91e11ebda21cc2c84a2a540072e656d2a8e6fcea7808421"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.github.stephenc.jcip/jcip-annotations@1.0-1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.github.stephenc.jcip/jcip-annotations@1.0-1?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.apache.commons",
+      "name": "commons-lang3",
+      "version": "3.5",
+      "description": "Apache Commons Lang, a package of Java utility classes for the classes that are in java.lang's hierarchy, or are considered to be so standard as to justify existence in java.lang.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "780b5a8b72eebe6d0dbff1c11b5658fa"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8ac96fc686512d777fca85e144f196cd7cfe0c0aec23127229497d1a38ff651c"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "9e6ff20e891b6835d5926c90f237d55931e75723c8b88d6417926393e077e71013dab006372d34a6b5801e6ca3ce080a00f202cba700cab5aabfc17bbbdcab36"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "7f2b9465c12f8220e45965acbe84597575d19eb267b39f4dc9b2d049ca686c3866bcc7fa8bba9e6c7cf6fc437e6c4baa"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "dd6fe38145f4a33f121230ecb9d4ac413c062dfdaee8384363c7c3daeae6148f24ca039deb53c01987f462232efc6148"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "6dfb55efab5ed388530cc40b1734fc4ec7548f5ad55011033bdcfdf4d6311274"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "7e7e888c315ef62dd11fa6bb933ec10432fe58d02fc6a60bfa4ed49f5b610a6948474d309a9dc90614e76b0a865eae4630ce9b40a7110414f1b20b499d2283b3"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/org.apache.commons/commons-lang3@3.5?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.commons/commons-lang3@3.5?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.apache.commons",
+      "name": "commons-collections4",
+      "version": "4.1",
+      "description": "The Apache Commons Collections package contains types that extend and augment the Java Collections Framework.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "45af6a8e5b51d5945de6c7411e290bd1"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a4cf4688fe1c7e3a63aa636cc96d013af537768e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "b1fe8b5968b57d8465425357ed2d9dc695504518bed2df5b565c4b8e68c1c8a5"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "1553751f9126b24f8c893b169df881052483ccf1586efeed4215b6ef013e115e001b96a09d348055df6d1be338a0fa1b14b28fedca3f1663273931a7d17e1363"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "76724283c14e799f161e999cfe24a2444764a83027c2fc43099153c6586d704682eca31b045c3adcfd9440fa073af4da"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "54c6fd77fd95fe1859438d5e550ae5f82f13b8ea4e789a4c9c1d0de943b6a16c142bf1f422dec9e075d3e5f9d052b27e"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "874dea7fc249c98eafa0bed0801583cd84393b7ef4d1fcb3d0451a8d83335fc5"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "a72d4f6987f253753e2f6b5e1367493e4261d935e5e84c9f487f48beaf05702dc0fd90050e830a9edcc56b3a075beb26a72741360eb7691208b73e3d771b675e"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/org.apache.commons/commons-collections4@4.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.commons/commons-collections4@4.1?type=jar"
+    },
+    {
+      "publisher": "Chemouni Uriel",
+      "group": "net.minidev",
+      "name": "json-smart",
+      "version": "1.3.1",
+      "description": "JSON (JavaScript Object Notation) is a lightweight data-interchange format. It is easy for humans to read and write. It is easy for machines to parse and generate. It is based on a subset of the JavaScript Programming Language, Standard ECMA-262 3rd Edition - December 1999. JSON is a text format that is completely language independent but uses conventions that are familiar to programmers of the C-family of languages, including C, C++, C#, Java, JavaScript, Perl, Python, and many others. These properties make JSON an ideal data-interchange language.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "b4f09b247c03cc2d091502d5b1db1f7f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "69b3835e96d282ec85fc2e1517b8164c45ed639e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ac3689112788e042088755e63ecd1f689adfeb04d7fb1cfd244513f94f82522c"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "92fd0d0d276a1cd619857fb79aec20606bbc19405b5a7bfb6e4b968f877573184bec04bb4b28f1ffae7a3eaaf072f944338bbc1a795d62853b9eb0899f94edc6"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "2f495d95c9b97a1e0cfef7ab90a9f29bb69f22232c1083250e414e0785265227febcee2fcae19ee1ee03ef5dc5fea634"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "25f3e2698dfdbb9f9727ab45e827b3a8b9cbbb1742c0af377335a39b25b6b89c45593d984ae81653b07952867263c32e"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "f2097c31a5796c4da739498aac1f23d4e7a2beed81a0478996687f3698f6887d"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "460154ecef1e86bbc5961236878e59a478e50aef42a81501fca644a1ca1bd6436d630c4e86573cc6d40f44146cf4378aacd2d209edca2be0af07fb3c500616f5"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/net.minidev/json-smart@1.3.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/net.minidev/json-smart@1.3.1?type=jar"
+    },
+    {
+      "publisher": "Connect2id Ltd.",
+      "group": "com.nimbusds",
+      "name": "lang-tag",
+      "version": "1.7",
+      "description": "Java implementation of \"Tags for Identifying Languages\" (RFC 5646)",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "31b8a4f76fdbf21f1d667f9d6618e0b2"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "97c73ecd70bc7e8eefb26c5eea84f251a63f1031"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e8c1c594e2425bdbea2d860de55c69b69fc5d59454452449a0f0913c2a5b8a31"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "494267766c974ce16a99cb221953edc91fde8db0c920230758ecea0ea9d3006e95d86ad46f7a9d61b810d85b0fa6da9a3ce2b507cdbe4be320c499eaea93666b"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "fdc2cde39a1b07a2542cbc07222afd6292ae19cb1f9ae008476f7ec1b8ebe1e3e84aca08e47e1ef81887a23ac5267d00"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "b0e673087533f60173a11a55b0fde554c0830e7b3b6609e1ea6546de19fc9a97fbfe6eee73580d09b2de66989d0603c7"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "ea208d4eb55212ce9835a9be60396861b0fc33f4161efee3736c3e7159acb9f7"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "450f819981d73711c30d838261ff55a7f1988c8b965c786708dc27fbd10a2018cfde82b8fee5d7d1022eacf085dfdabe22d9de92462eba80e2c15a116c3c73ed"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.nimbusds/lang-tag@1.7?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.nimbusds/lang-tag@1.7?type=jar"
+    },
+    {
+      "publisher": "Connect2id Ltd.",
+      "group": "com.nimbusds",
+      "name": "nimbus-jose-jwt",
+      "version": "4.35",
+      "description": "Java library for Javascript Object Signing and Encryption (JOSE) and JSON Web Tokens (JWT)",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "00a2572788c8afec086aea29c3331fdd"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "04d248635461bb1998f832401d8ed25a229a849d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f83d3bd5ea4924bbf209995a9bd24b5eaf8731d4ee1d8c3febafaf4fd4b311aa"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "7e70c5ce546cb5e5ec5c6fae6eb6a4f81c2d12e89b9162e9d61039a74e477cd4a53a5a2271a24d61f1cdd5b89797f6207577b1120b21f90863ad33794295669c"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "a245c4800d630c0b00281aa053ec655b3d8d35eed1844f2b824ba70473b450b3f848c3def394475282b8bd676a111249"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "5c3c7d3d927a2af512bc4b10229d3a09fb665818deaccbee7048b2adf6aa16d8298cbe0ea665334fa8b941f3fc67f650"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "39599d83151158c34d3cf7fc91fe57542eb38b08df8c533fc99b34d120a53850"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "a3d9ac8f76530d45c9071e760c5beedc0373a33859346c479289625d623fe0383e0c5c5cf571d808fcc857d27599fe15f5b4bed72f978eabb5754c12cb67983e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.nimbusds/nimbus-jose-jwt@4.35?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.nimbusds/nimbus-jose-jwt@4.35?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.bouncycastle",
+      "name": "bcpkix-jdk15on",
+      "version": "1.55",
+      "description": "The Bouncy Castle Java APIs for CMS, PKCS, EAC, TSP, CMP, CRMF, OCSP, and certificate generation. This jar contains APIs for JDK 1.5 to JDK 1.8. The APIs can be used in conjunction with a JCE/JCA provider such as the one provided with the Bouncy Castle Cryptography APIs.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "9e17685b340a4e22fec6733cf65ed5ac"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6392d8cba22b722c6570d660ca0b3921ff1bae4f"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d7cc06e92f0d117989cc7035f697c69c7c355838b2de3dc35491441afea09ca9"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "047d6731e1905d2a88204ef89307e9ff2d145492d8d9f99263aa92c8a81bff43a517e382e5d5a7b4422b68f338548272dee2e51811d0f3180f3cffcc06fc5f75"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "65a61d4d3961c31b49c4cf622403e897296a493b2af5a18f530da58bb129d705b65e9b2cc2051279505a2514004b5dec"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "f1434706ba0d2c39da1d0bceeeb92ab57455f7d8c390fb92c49cb9e0b463d845480dc37d3d1804eacc38e43bc1f7382c"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "c981ba4a0868080a74cc045a575009f7418629baa83d67df581eec80a35ae35f"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "87d633848b02093309fd61f423d20b045da9ecc739c60b3010c7a7b2172f746774bfd3bd1affccf0e4546ed5cf95a273cc4033c85184365ad04701705fcb4524"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Bouncy Castle Licence",
+            "url": "http://www.bouncycastle.org/licence.html"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.bouncycastle/bcpkix-jdk15on@1.55?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.bouncycastle/bcpkix-jdk15on@1.55?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.bouncycastle",
+      "name": "bcprov-jdk15on",
+      "version": "1.55",
+      "description": "The Bouncy Castle Crypto package is a Java implementation of cryptographic algorithms. This jar contains JCE provider and lightweight API for the Bouncy Castle Cryptography APIs for JDK 1.5 to JDK 1.8.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "cbf56e979aba0e551a57953080e115f0"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "935f2e57a00ec2c489cbd2ad830d4a399708f979"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c08450a176b55c7ef4847111550eb247e5912ad450c8c225fa2f7cab74ce608b"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "7b66813a9d1e0ca5c4c1992eb4b453c105ace2bd08615d5d7c36faf80371fa93c583f6a751dbdcfcb6861ec05e7128d556354a097b031a5e8e876f417256f641"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "fe7fd49456bfea10780dc52ab3802f8d35ffeef52647700e2c58ad6f803197c09d976bc3d9c9e49ce0ab1f3311a00fc9"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "f6da6209d4f2750aa785bf79819ec1a4aea91ba5cf57b5d672ae42fec6901140a2531d23059e4aa68e9814afbb75064f"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "a4499a53301c65f059ff6c188d0bc79465f76120bf26be504b9260409c614c90"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "64d0c0951f7ce5eb3964162dfc9e869e6a0de4ec461d1218492293afbbcbe377637d3e62b7b6ff444097d3e019fdd16de12faa89ffa73036f3d093b97f8fa49e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Bouncy Castle Licence",
+            "url": "http://www.bouncycastle.org/licence.html"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.55?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.55?type=jar"
+    },
+    {
+      "publisher": "Sxip",
+      "group": "org.openid4java",
+      "name": "openid4java",
+      "version": "1.0.0",
+      "description": "OpenID4Java library offers support for OpenID-enabling a consumer site or implementing an OpenID Provider server.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d75a54e3a1c86b6a6e8ba9f9d5043224"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "541091bb49f2c0d583544c5bb1e6df7612d31e3e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "477702693a55ac4070a38171e7d52f1bb86de97b040eaff59f7ee3edf42edb2a"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "31087ca17f566ea316eae70b54d02a9646602cb83c0c66bebe3b9ee2269377b90553a60a9b1c6a176ed40c712b1b5c8217bf9d37977eea9cb9a5210be668eeb2"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "065db020efa71ec37f8e6d62f0e4431ee679f059548eeb55b26d8f2c9fd4ff82fcc82aaf84a4bb744dd3f47e69b4f219"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "f0820aeb9943d3d8716fc924991611bcdf1ed610a9e914fb44025df16bc10c5b251f8ec5cb65339b20267913525cd946"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "aedeae5c23773b4a70c01b37708fabfb3c2b339d785713ec3007f339c52ca678"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "68bf0d27a2798ca3456ca0b40ff94f34a19758c7a68d6c959418a3e3b656cb53fa3a952ecaa6cec6d54535b8afcd37d7dec46482afde9bcd416793f0e3ccba69"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.openid4java/openid4java@1.0.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.openid4java/openid4java@1.0.0?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "org.apache.httpcomponents",
+      "name": "httpclient",
+      "version": "4.1",
+      "description": "HttpComponents Client (base module)",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "241e32c3115c3d3d2bfde8345e763a56"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "93cd011acb220de08b57d96106e5800d7097742b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e554d8bdeeceba93d746729fb6d09102668459b57b10a0858185718201eee289"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "f30ca31d555bbd8c3fe33b11e55eb1969495a9ac5bfc6e0d708b7d4031b93b59d39dd9cf73c0df01b680d911e95a06d5b2976257fae8bfacc888a9b259351547"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "bda04f42fe740367567945aa84179bfffcb4e370b9041727ecf01d228ff99137bbf3b528bfac087a13aceef34f57286d"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "8791ec3b068381ca1c51bd70adca7d457614577270926b9934e895f4747e0cc566b701662c8351e7d9c7c487cce9bf8a"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "692d3a9de61f5e54a7a01ae107f4ed386afab6405ce846741696db63b1c2b67b"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "9261ea313f69281ca1aed2034b45a2ef220e713201ed1790f6fc0ccbe047c9b8ab163474e1aa95ea758193d963fb422e9d1f452b5cfc55d375c62caaafa1d006"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-1.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.httpcomponents/httpclient@4.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.httpcomponents/httpclient@4.1?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "org.apache.httpcomponents",
+      "name": "httpcore",
+      "version": "4.1",
+      "description": "HttpComponents Core (blocking I/O)",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "db31aa554da6b48e36351001fc6c6d14"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "33fc26c02f8043ab0ede19eadc8c9885386b255c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "3ce38de51f4e24668c6d184057a8d08541f9e815d2d319d0f462f083092b29cf"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "b463ec2e3fc27ccaa69b50e6eb35e89d2df9bc0e6b50e2bd4419a70c4058af3f456d25bde6e625915ebc5a010824dd8efd1176f3854a5d8bbb261b6a49c38429"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "1d091b9c43dd7bf2a26d221947d862aab1b72a0bb519142d90afafa284047fd95815224a5111b0f4f468ef082d98b916"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "3d9f52b252f7aa3e9f8122143f4a8689ee8199914c6fc07f41b00408f7c4278b25e4fee4fbaaad891fc95cba1be167aa"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "be4f692cd5f3d5284533f9fa6f1181730a4d4798d5fdbdd9fc95aefde476ea3f"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "9a6f33cf7db098a569cc6bb20d7214e911e5cf9982ade94746259b3ed872ee37088225b3a530a8d3942fc0dc0e13ea132db39101d813ea8b51869a6c624a0d5c"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-1.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.httpcomponents/httpcore@4.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.httpcomponents/httpcore@4.1?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "net.sourceforge.nekohtml",
+      "name": "nekohtml",
+      "version": "1.9.10",
+      "description": "",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c8c1857d69660fc395cb98d276adaf33"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "14052461031a7054aa094f5573792feb6686d3de"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f44f6f6b355dfb083cdbd5b33c9d7920fef0c77281095df30a2b18ba5eb60d69"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "c360205234269425a3dd2b487f2da405fec348519cc9959bf8145c1aaf80f7112b2f207a8ea62540d2493fcd80476436db420e6ede1165153c5045380f6fe39c"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "ff75f6bb23a9546017114b7716be4714a6e4792002116977f120aaca9baa662a0172c86e0e2410009f31c216cef84146"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "0e3207dcc103659a8c988b92157427b92a967dfbeeb121a16ceb1bcced1022d8af7aa664122a0849c7ff6760ebe06945"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "6156f69a563c69eeed87d7086351420d447f44e905f1637877b10c03febc9d84"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "3358f3e8f6daa30ec62aab40355be5179ec29e1c2903fa603877999ae031ac5a87b3ab85fb45c432cc6a34041342b3c8e4fe51664bb5a1b87dde28c7604d5116"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/net.sourceforge.nekohtml/nekohtml@1.9.10?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/net.sourceforge.nekohtml/nekohtml@1.9.10?type=jar"
+    },
+    {
+      "publisher": "Google",
+      "group": "com.google.inject",
+      "name": "guice",
+      "version": "2.0",
+      "description": "Guice (pronounced 'juice') is a lightweight dependency injection framework for Java 5 and above, brought to you by Google.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "0fc35ce963248ab0ce6ba6c148f9b665"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "a4c67006178262122e93121e94fff306fcf0cda1"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "9fb545199584a41e8064e1232ca3f3c757366b27fc7aa488ac0fc98263642756"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "9095a15b000f1a55a5321099326746caa83dd3095e6baac3f40978c4114be7d98fb28bf0738a66741fcf2c49d47256bc036e0b067cae6e755028bdbfc45b9d68"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "caabd744152efc2f9d0458cdf8690a9bb2d495671cd7bee294e55f32be3c673b871424441dcc5afc27aeac2168afeb45"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "325da7b987384e34af07390aca8fe30339de78fbe31fb6cf7f9da04f77f17b53ab3658c038b098d7a055bf0ee39e9f24"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "966c01e852904b7b01dd7f0040751936e4cfa3b233a364656ccae90794d60adc"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "28512cfbb86fe227f42743877bd61bf818e5336ec33bf4b7e5338309709546a68509b00d7903ff4fe2f2a2a7879d9c6604e7489b9f44a2c8789c5de09bcfbde1"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.google.inject/guice@2.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.google.inject/guice@2.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "aopalliance",
+      "name": "aopalliance",
+      "version": "1.0",
+      "description": "AOP Alliance",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "04177054e180d09e3998808efa0401c7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0235ba8b489512805ac13a8f9ea77a1ca5ebe3e8"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "3f44a932d8c00cfeee2eb057bcd7c301a2d029063e0a916e1e20b3aec4877d19d67a2fd8aaf58fa2d5a00133d1602128a7f50912ffb6cabc7b0fdc7fbda3f8a1"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "4dddf44338b5aff9580da2532b81c0ac3e1d09e1f28c6db871a55cad442b705dd7791eb07f9d4577d49d0be3673ba783"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "2bd64cbaf769c6e4e85e34f7a6119d89e16fbf55af3fc5d6cbd52eb214c367dec1ac7b9062ee0fb35a2e0acfc7c477e1"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "d4a726b2bf8aa58197021a7d8fca674b4b2790d4c48de43a92f728866a91c2f0"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "830bc3f8328be76897990e9b9fc42eef02623115e456af96ad09b20900ad615519c8c8de60155ac04fb332eaa9510110d52edd13911af76271c71d91cbd789cc"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "purl": "pkg:maven/aopalliance/aopalliance@1.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/aopalliance/aopalliance@1.0?type=jar"
+    },
+    {
+      "publisher": "Apache Software Foundation",
+      "group": "xerces",
+      "name": "xercesImpl",
+      "version": "2.8.1",
+      "description": "Xerces2 is the next generation of high performance, fully compliant XML parsers in the Apache Xerces family. This new version of Xerces introduces the Xerces Native Interface (XNI), a complete framework for building parser components and configurations that is extremely modular and easy to program.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e86f321c8191b37bd720ff5679f57288"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "25101e37ec0c907db6f0612cbf106ee519c1aef1"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f95f3ad141bdff5a64962f6c26b4f18ecf0975cd3a68802712284b9e6db37e1b"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "c4ed15789be4c8307f319b3217847c13cf2c80e210160a2f1bf4f884622a34d81064042e9f95f90ef14ef1e36e837fb691caf2eabb3ca86f11f57884aa10ba23"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "10c531b56f883f28f553be43b4ee957251a0a4ec8c03c29146612f5b57d2e7c5bec6508e532280ea319cde2d21e8fdb2"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "3cedbddfe71e7cea5c09c8edb2b030cdd74add21e48989db8230f264127cab46cde964b5d1f4291020380ef3f4648358"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "e0850973235719b7932f205b8cda851c2f83e327258102a25d49b55ee052cbc0"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "91acdec2a031b2381f852b3fdb5ab383b2d0fbf4c7d93df2f3c334ffbe75968dc45c51e8f04b4eb2c2293c90ec5cfc8d08d4fa3c4869b5ff8f9b79e5a5720d52"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/xerces/xercesImpl@2.8.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/xerces/xercesImpl@2.8.1?type=jar"
+    },
+    {
+      "publisher": "Apache Software Foundation",
+      "group": "xml-apis",
+      "name": "xml-apis",
+      "version": "1.0.b2",
+      "description": "xml-commons provides an Apache-hosted set of DOM, SAX, and JAXP interfaces for use in other xml-based projects. Our hope is that we can standardize on both a common version and packaging scheme for these critical XML standards interfaces to make the lives of both our developers and users easier. The External Components portion of xml-commons contains interfaces that are defined by external standards organizations. For DOM, that's the W3C; for SAX it's David Megginson and sax.sourceforge.net; for JAXP it's Sun.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "458715c0f7646a56b1c6ad3138098beb"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "3136ca936f64c9d68529f048c2618bd356bf85c9"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8232f3482c346d843e5e3fb361055771c1acc105b6d8a189eb9018c55948cf9f"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "daee51f0f564979c941b41e27a7129617ce9d791a4e1c4b618a29ae33ec9c78201ac516685cadfd073fda250d50eb2c0d651474103e7c4577e4bfa7d5f2052a1"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "159031ff0cc48506d2c3e00a67e7ce71258f448bf688f35938c5928e63ae0b2c9bc04f05c2d1a7da7a63509c34053795"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "31a3ce19f7696f2e647164b434080a8ddc600102c4cc7028099ba01770e357fa89c140134da58900865680333f5e4b2d"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "409a8b4b81661ba4bf99f28014dea0eee23c144097fb128690cb31fe2e0d7ca2"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "64e6d427b0fe24643905f773e08c10ccff0cd35173241792122d364f16d7cc78366cce15d7917e58be6a69372544f57267d8eb748679edb067af1698869137e6"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/xml-apis/xml-apis@1.0.b2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/xml-apis/xml-apis@1.0.b2?type=jar"
+    },
+    {
+      "publisher": "Shibboleth Consortium",
+      "group": "org.opensaml",
+      "name": "opensaml-core",
+      "version": "3.3.0",
+      "description": "Core",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e558149f017f5e7dd948658f76d7a44a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6fac68342891abec3c22d53e14c706ba3e58918b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "23485da0ab41c864fbaa23e09a6aa40507683f73a51d1258f16e4321df1f1a4f"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "a4b3348173fb68aa1a9b26359ccc8ae83f06aaf87aa93f61f0a053f8a383f4feb82b10e3e367f6fa8f2f12060e5381423b0ca09a1121a1eb9c5ea9e27139e0f7"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "15be3dff76c163c5fdd50fcbff19d356fa91223701780efcbaad028dffaf272b1b05807f3dd2cca89affa1c4538a4051"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "f7753a9cd84a1a005c4517f87cc6d3dbb125a388a2507c81cbe5bbe3d88870e5dbf5c249bc645041be826baa02641acb"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "cb93fe9905acd0665e1cd2f57acbc6ba7e28c043c6b2e60534abea34a7619698"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "00b0d5089f462b7021997e6b6894f30cc5e7644be4dd4cde768923b40cacabefb3bc0187b955f4adc3d1e995a462bd5aaaa5afcb4d0a74e54706cd270302e627"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.opensaml/opensaml-core@3.3.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.opensaml/opensaml-core@3.3.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "io.dropwizard.metrics",
+      "name": "metrics-core",
+      "version": "3.1.2",
+      "description": "Metrics is a Java library which gives you unparalleled insight into what your code does in production. Metrics provides a powerful toolkit of ways to measure the behavior of critical components in your production environment.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "b8b2de75247322a0c037420f5708e592"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "224f03afd2521c6c94632f566beb1bb5ee32cf07"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "245ba2a66a9bc710ce4db14711126e77bcb4e6d96ef7e622659280f3c90cbb5c"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "d22c007d1fdf0ec25bdeb4ceafc89009d80a746441d49d8be433be9a2a4af6de34b119a02c8270bdc50f3a4041944a2c99fd546bff85922b782607ec4f8fbd7d"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "82aacdf0818ed310c816cbc1427b1c0922d810154ae15f84e4c62173f596a65f9d07fe8a7e4675d1a821a3dd190ce418"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "f00c1d703da10cd72dca42f778760410637ef24bca14a9fd0393a419109ad6b3fce7384c202d1fa89467571a0fc878ae"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "3c1e2f0954ef6ff9f5ccb203a85ecbf7f1e6c8d38421c793d3b8eadf685999f1"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "1bac2b35125754b695950a568ab17822afcdc5ead469209cbc41a85d08fba7d64308b4f10b6c63c4eb200ebef198c92a7438311c6ee0d93691e43a2bd0fcbd3e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.dropwizard.metrics/metrics-core@3.1.2?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/io.dropwizard.metrics/metrics-core@3.1.2?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "commons-codec",
+      "name": "commons-codec",
+      "version": "1.10",
+      "description": "The Apache Commons Codec package contains simple encoder and decoders for various formats such as Base64 and Hexadecimal. In addition to these widely used encoders and decoders, the codec package also maintains a collection of phonetic encoding utilities.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "353cf6a2bdba09595ccfa073b78c7fcb"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "4b95f4897fa13f2cd904aee711aeafc0c5295cd8"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4241dfa94e711d435f29a4604a3e2de5c4aa3c165e23bd066be6fc1fc4309569"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "8edecc0faf38e8620460909d8191837f34e2bb2ce853677c486c5e79bb79e88d043c3aed69c11f1365c4884827052ee4e1c18ca56e38d1a5bc0ce15c57daeee3"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "8412e1f64746422f1875a811c71c51b6e45512a6255ff47e3b2b437bf6fb12eeea3910e3c1a0bb3caad672d3ae15852d"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "7a02456a52fb37324fdc2d31f6ef958b898de479fedf32244facf7104b3dc1834761cc1f90c5dad74be76fcd980d09c5"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "5491c5ce96af7ee3af286d6095baf71cffbc80e110b3a6c5951b3a108d717343"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "473ad932b9f0851c7548e47304ce30567fb528ece28df818b61f42ea04f6198ef60f6f73c7b22cff612d61d3a6efaf0c7a0dec3922fea2bf4493d32f0a6dff41"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/commons-codec/commons-codec@1.10?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/commons-codec/commons-codec@1.10?type=jar"
+    },
+    {
+      "publisher": "Shibboleth Consortium",
+      "group": "net.shibboleth.utilities",
+      "name": "java-support",
+      "version": "7.3.0",
+      "description": "A POM containing properties, profiles, plugin configurations, etc. that are common across all Shibboleth V3 projects.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "67b23622febcf0461863d52ccb4776d8"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "288ecc17f2025ad14f768163d42808987d5ffcd6"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "b7b21ebba678ed560c1cf5883a7d49b014e0adba48bf2a10e36578dd6534f852"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "24677fee04e376793b1a588f54c2e6398d69a54c7a903ca7e92f1132f61d2af9cd124f12045c8ab8adef5e37277a9f75b879290778b82382a11f32b4d7f1da58"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "b97eae5267ec574e37c2d8399a2ef7f19a3ee0b52ef1f7ad4765ec972ed617e7ca8eb6e7b3be8f304cc4784d8129a3f0"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "0cfd209bcb6337b12fdd2f1793034dbc23e15b2b3a3e08942da66f7b3590a8b9aac0b882a3dcce418febfc5582e5c8aa"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "a6ab520efd16ef93df59839c54c7e4554a82015a620735834c8dd06caeb4a6d4"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "72559d07344950810e78d25f9f9a719c4626dcbe881d26563a7a2c3200a6c5fde7c5840f84d176cee8dba8eb27164d0348270b75f1fcc307326c23c738c8c16c"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/net.shibboleth.utilities/java-support@7.3.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/net.shibboleth.utilities/java-support@7.3.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "com.google.code.findbugs",
+      "name": "jsr305",
+      "version": "3.0.1",
+      "description": "JSR305 Annotations for Findbugs",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c6532beb3f7cc54a8d73d25d5602b9e4"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f7be08ec23c21485b9b5a1cf1654c2ec8c58168d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c885ce34249682bc0236b4a7d56efcc12048e6135a5baf7a9cde8ad8cda13fcd"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "cd537b74b44421f398832d610142c161a292851ad3b1657cfd8c530749b1fb16a13ae596abd58e419093b258d6db943ce9535b7d4a2094871a0d20d29d12c408"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "045b35afb978db023ef70c49232d6eecefd4423f1b08247c236477229f4ec7766cb7a0ae2a5d2ef81b3b69f61b5acbd4"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "ac75d613ee701b9acc90089b67de850f1618f4e940ae01d3f07ea1f892d455402595006e3f433ec6142d46e8b2e92afa"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "63e3ba35cbe04d0bb2a4cfca0c6471e56cf8b4a2bdf051a444b399b6d0caef64"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "7b321a6e97ae8e31c3a55c87cb14f09dcedf0e0ed47e5c7ea4b25ff928fff9a7db19352d82baf0c7362759e5cfb000dd12b557dec8b45a6142425ef46920535c"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.1?type=jar"
+    },
+    {
+      "publisher": "Shibboleth Consortium",
+      "group": "org.opensaml",
+      "name": "opensaml-saml-api",
+      "version": "3.3.0",
+      "description": "SAML Provider API",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c681c20398b65bd9b73c0a15b58f5c16"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c9611395e073206e59816b0b5ce5166450e8101e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d018033e842ddf5ae5b21e5f1461beb45257a1ef4a6876a468524dfd409ba09b"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "591fa69f32bda406f6cd11a9fac96edb6c1d1a78648e7f2c9489e4268b634e1b39b7aca53c40719231d6cfeea795c2b89af8fb7b3900660eb05468dff6cfc54f"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "a0c74c5a8f12131794c501a92e19d852c00de13f4e86a2fea711333e41ee49eb6c726c069d31376ac7690f00ed57a96e"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "4c246a0fb74a7f5235ac3fc771e56ac36bf8454b32e628e5d1929a833a166eada4bff832d8bd1fa4fe3ccae8764a9c05"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "b06b8bbf609118f8c42efbf62825c9bba47032b8c65f88fbd431c63be6d00fbb"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "8c2cc312021fcdce2c4a8c09a2c29dd5f855431bf4d2fa9b5feb1d43cc2bee717f6b0e12b70796952f44108c6eeaadf047119e8caee0f19106e950c0198cc3ab"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.opensaml/opensaml-saml-api@3.3.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.opensaml/opensaml-saml-api@3.3.0?type=jar"
+    },
+    {
+      "publisher": "Shibboleth Consortium",
+      "group": "org.opensaml",
+      "name": "opensaml-storage-api",
+      "version": "3.3.0",
+      "description": "Storage API",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "71395679b09b72d62c07f04b7c7ea12e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "7492688b067dca0568554ec4c7abf9f0b5e1f682"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e6bd158b3537a6e9e8307d9e7cdaf3f7127308d2801cf94387194669126a2398"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "3e2e068d3e62c4c68eb9b51a1bb12418827644d81c335cfe9a403ba38ffddf3111f9f4fa1d6e2f69c4d4069f8ea446bb6b9612275509de2374c8032c57ee8e19"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "7a850d7b9a2e922de3f68a185aca92b8de531f71830a52e13a766255a14dffa0a63f1581c4624f91dcd2e48db3d79121"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "b1f9051274a1265cd2e8f7fd2a7aff82ee17852c92dbbdbb3c46a4e75147fa5356bdcf506259fd19131a932bf90f19c6"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "24a077d1cea695bb773f62421061d2d6c0e4f864745371c39ba15f50064d12e1"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "6240cb232bc82642b60d78406e4fd8291d1a757edfbe4c23dc807212986051d5b9690a46e864f650b049db27b1d5267772a2509d2e323a01afccdf80a3588fdd"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.opensaml/opensaml-storage-api@3.3.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.opensaml/opensaml-storage-api@3.3.0?type=jar"
+    },
+    {
+      "publisher": "Shibboleth Consortium",
+      "group": "org.opensaml",
+      "name": "opensaml-saml-impl",
+      "version": "3.3.0",
+      "description": "SAML Provider Implementations",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "8f6b1c6321b7d9b64d11e70d2496bdeb"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "391ac88f96a9f8f522d693c168d4c65fad20535d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "547913ef8a3b29a3d3535f7885ee65bfd9a30e87468c20b6ac41bff91f7cebc7"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "a7ee227f6f7ffc7c690f6222fcb3583923c389e8e22c1815ddb857fe81ce148b0f2b178faa239fc072c07891bfb31408afa2d66d340837927e08793579850d9d"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "7e890293538f6bdc29ea684182facf2043172718b79cc06b8fdaf338494a79fd52780fe6ab37aea007af16c525f7492b"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "f887f75685e5329d2766bd2e4c240361a74ce46333b02503205038a1ecb716810aabe8b63724a6b1aef24277d49e5b76"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "e098c37954d178e8885ab77b9bc2d9b77669a2335080bcdc5ff26bca87a6016a"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "274f02f595e861c024295f2ade47bfeb085b6cd9c133ad8ddad4e7f05dcfd4dc93ad1815b27a7a9ec3c5458a7188b7e13f160235455c67f305696e425076287a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.opensaml/opensaml-saml-impl@3.3.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.opensaml/opensaml-saml-impl@3.3.0?type=jar"
+    },
+    {
+      "publisher": "Shibboleth Consortium",
+      "group": "org.opensaml",
+      "name": "opensaml-soap-impl",
+      "version": "3.3.0",
+      "description": "SOAP Provider Implementations",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "fec040645bab7c675552af8ba522feca"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ea912fe660d11ad443775974e3208f0563edcebd"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "4b4c0832e47ca7717c13181fdfd488754983f0c6cb4cf10a95cce0b01348b961"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "b06779462d1df010730b2ef85614b8a5d41891619d488ec9bb13f6afe1933d9d4962c480a2e40a9011c694dacea0e10977379c018b601198db136927fc872146"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "6555193bf4052ccdf02e25b19e727cca9ca950b887443daee60458a7dfc5bf7962f3c5905e95d416fc51c4f1a8fc5ed0"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "92837bd6556dfaa283d8e83bcf0ab9c71b0e0ec2eee283a47020d7acddab46cee79d68f6a012e6ba1ab4a3719a2fe944"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "ec79f63987a7c2be93b0aa140e16df395ff2d76cd3bebfe2fa60247085b97534"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "e46165b32b967925447d9ce861ed65b604d9fbd51e02cb2969e8a9f1e36515aeabd5b0b920ff218154a4f23e262107562f37a9dcad1856e2de799cc69773d585"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.opensaml/opensaml-soap-impl@3.3.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.opensaml/opensaml-soap-impl@3.3.0?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "org.apache.httpcomponents",
+      "name": "httpclient",
+      "version": "4.3.6",
+      "description": "HttpComponents Client",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2d29a27bb6c6b44bc8a608a0e5d09735"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "4c47155e3e6c9a41a28db36680b828ced53b8af4"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "79838d9eaef73d4f852c63a480830c3a2d4b590f0ab3ae815a489463e4714004"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "3a2978faa894cb2c104b65ace76936a702e6fbb0b75f3ca53abe947e636656b2f62b16d5320e4e0d6d954dd07005649c4c40d8b4ca7744b2ea91e8df1e96a1c2"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "9e180f692863afdd914ca6d39177d12a96adb8e0924f4189af4c745c028754175aab922e7625e21255a1a40d95f9d54f"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "152f2ad0ffe05b0f27a1fdf9f833c4fd3c04a9671427ffd485c965d392e62ac9c340191d841effe999016ac9103fc81f"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "97bdee27354a8dfc6d63e3c77813d926529158c568567347ee71368e65ba3a11"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "f8f7088b428db0d0c9e5d946bb5591dcbc0798b954625abdc34f603fcc800bb44d62e4cc9e407aa7a92acb72691dbf9ebec7c7d152ea2b8e697e1052e4352ad9"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.httpcomponents/httpclient@4.3.6?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.httpcomponents/httpclient@4.3.6?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "org.apache.httpcomponents",
+      "name": "httpcore",
+      "version": "4.3.3",
+      "description": "HttpComponents Core (blocking I/O)",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c26171852f9810cd3d2416604a387e71"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f91b7a4aadc5cf486df6e4634748d7dd7a73f06d"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5285de80af1651c489313b91a9f40c65a4cdcb6b3bde716fcc028d16869a5a93"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "3a29bcdea57838fa460e4eb10232e6e84da3ebdc6e48fa97b3a8c6d291ba1c98973bc3aeb2acf5f4b9fdfc9be8540eafd47e9bc8213735079b882d049369fa04"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "805317beee2b91ebf4abd8e074ec51b4002a7334ea4a3563a6d29a567490f870aec4c82e4f89fce6f3583e6dacf70e69"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "9bd8f4e88073d6a172df7790f0a8221937a25d680d905195ee0d4de2462ecbb0b0800b6912762ac222f9e6f0104d7d55"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "5805b37d4b1aaa2fc65a2e75846e071dbce22b227a3fa3a45c9a9faf05a340db"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "2862773f01298a32f66bd55378ac4c3b82c1826809e0051599d4a3fa4bf2140c97db11dce76c5d8e456a22792f18f1afeb839bdce079917c88b6cce43e94476a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.httpcomponents/httpcore@4.3.3?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.httpcomponents/httpcore@4.3.3?type=jar"
+    },
+    {
+      "publisher": "Shibboleth Consortium",
+      "group": "org.opensaml",
+      "name": "opensaml-soap-api",
+      "version": "3.3.0",
+      "description": "SOAP Provider API",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "9e7b62c2ce6917dcd84f3283de346428"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "4e900056cd80c1f0bd72497c26a48664089e04a8"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "aa106297d3eb7178e992408b197b0a5d7461bcd9b30e50d730bee652d6dd07c8"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "a7bddf4ef6723d26d0863f613be40bf3dea56aedf517b583af5f4be474176625bbfaf672d119554778dfcc6d4f9fc90cf75a14c526c9c1663cbef7832d9b06ec"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "9162e9ce854bf5204e17a896a748c1d022787934c8432fe277733e8b51a2829cc57ffc9303cfcb5bfbacc864f75b803f"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "c6c383c24c34c69ee681ca722793c9e0638241b5d92abbb4c510a83ebeb8646ee7822a7a05fb8d0389e7b838c873ab1f"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "a08c83a0c3500f351eb636cff171be1f0db149cdfb142afef548735c478d6364"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "b1a8864215d65b969a3132a4e605117b9883b0156043a393330c35c949da6f49042fc341aa6a25577905ae3431a96dc80ec3a31177ecad4af54c60398b9680b2"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.opensaml/opensaml-soap-api@3.3.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.opensaml/opensaml-soap-api@3.3.0?type=jar"
+    },
+    {
+      "publisher": "Shibboleth Consortium",
+      "group": "org.opensaml",
+      "name": "opensaml-xmlsec-api",
+      "version": "3.3.0",
+      "description": "XML Security API",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "b66b809860e35827ec3b44d3cff2b0e6"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e824f1e3ec14080412a4ab4b0807a13933d9be80"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "722f0c7168f9c2d790243d631b53cbae088c7247d0f52d4a1b4a729a207f17d5"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "35a85d6eecf77e595b74cd710b705a4eaea0d2e25b0bea89f556c6c176c799f4c28a914149f9c6fa2b1e2ff2530261e582a6c7f3f203f0b62024b724327a5817"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "de06f7282908dbf9885d8f91d32ac23570e6052edbfb587afde060f794ebfc0e426719694d0d50a3ad364821cb37f996"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "253f451698bbe8beae535d7d2bfbe2c901b6e2554bf7292e5116b0a39e7ccdfb25f3b752d1c5771e7e1f3c1b420bbfa4"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "37bd56f6d04b5f0a9354b92c57df8fbfb220121427a4c696f308c12e2540a95f"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "fa4b24716f454e67320cb947bd0f65c80c680e03306a933aa06f32a949a4839d6f0e35b300d2a50d09fd597800befd191cf6d6a785afdfff8022cd7e4ad2b8fa"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.opensaml/opensaml-xmlsec-api@3.3.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.opensaml/opensaml-xmlsec-api@3.3.0?type=jar"
+    },
+    {
+      "publisher": "Shibboleth Consortium",
+      "group": "org.opensaml",
+      "name": "opensaml-security-api",
+      "version": "3.3.0",
+      "description": "Security API",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f55dfbba0ac2e925856330ef94aa84b8"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "89477899f0836040e9a584b451895a61d923bf96"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7b36f7fc368bf5dc86473ea0622c568ef53afce1038f83556286ab45ad0a653f"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "27d6ac2d9747a74043adc58c3f5e90383b1c036b4f843e7ecb2dac1abc9988648833896b489077b5a38eec194264da5f9ecdc5da7adc40ce5a6329d91fb9eefc"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "dc73d9f058db9ed635f7b0c0b32aca48829e16874ef8d7b45be9107aa5c23171a82569cd7d64d5073a296775fdff0251"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "1ceaf6bc33e78b79c971b78a1e0c267011cd761a7afc5f8062f60a4a938bbc1dc3a9e6e753c029efdf288925c9ae6b6a"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "a10cc591f8d33ea5c4740c685cb1bc34f360a261cca32f58a0a8b45b58261ce2"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "2e937682e58400faac777af80f7cc57d3fb0e6d0bfd8fc8645bf0c45b984c84b85efeca3d16265f3ba3840b49d6cd066970a8201a2baf0ca9cb7ec158d538d81"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.opensaml/opensaml-security-api@3.3.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.opensaml/opensaml-security-api@3.3.0?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "org.apache.santuario",
+      "name": "xmlsec",
+      "version": "2.0.5",
+      "description": "Apache XML Security for Java supports XML-Signature Syntax and Processing, W3C Recommendation 12 February 2002, and XML Encryption Syntax and Processing, W3C Recommendation 10 December 2002. As of version 1.4, the library supports the standard Java API JSR-105: XML Digital Signature APIs.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1a2e53d45241f52a1064878b43ec1535"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5105288b83e56be8bbb5e5aeac362bd04820cf46"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7a3716230465e4c5bee1d5605d693de0bd12597beb34487278c7839e361137f7"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "0eddf24774edef4bc975c70c1c923ee22ba83b04d55b6c79f823d210b398e78291e4853a88dcad3c749e37cd366205ac6214c46470585136057b7fd65f833f14"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "79840d92e0974bdf221223d500d09b059ff51acc1e849acb995f9ebb1190adf6c67bd1cf00e2d0a7c5284948269aa62a"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "e9e864b57beb054dba5d0ae9211aacc22ce202a1cea961e6969665e7e3135fbc848b10f76472b1ef1c189fd8adf7a5c7"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "ba2e12dd2554c4d7cdf6b4f86ae5ac7fc7a1684de14480edb9b5006d66ed2117"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "a585f7797da9583a788f61ff5be177cea370eb1923b4588ae3f4e1e93e6fb9d52bdc06db85dbfd5b4dbee368ad8bed667e8c22f06ca05b58b5bb1b8034d26749"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.santuario/xmlsec@2.0.5?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.santuario/xmlsec@2.0.5?type=jar"
+    },
+    {
+      "publisher": "Codehaus",
+      "group": "org.codehaus.woodstox",
+      "name": "woodstox-core-asl",
+      "version": "4.4.1",
+      "description": "Woodstox is a high-performance XML processor that implements Stax (JSR-173) and SAX2 APIs",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1f53f91f117288fb2ef2e120f27e5498"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "84fee5eb1a4a1cefe65b6883c73b3fa83be3c1a1"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "274fa403ed08c0d6f2f574dc1916adaaaec9a493e56d6442f8797ede620bca65"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "33165cb587901e8908fa2589f16a6d1eeb87429936734e840b607e0a80c6a6680536eb8044536b871f3cd94b54ac734f51fdda9120bce0d2f58754c6822216d0"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "e9b4203ae09719337238413d5b8db19563b5a6f6fd3630a3c64b07f1e7a43b3b6e4bb9c3016fca264f3c1502462659fa"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "d1413e12aa17bd9fb902d6685b067392135770e562df138d51233557be6b4b5978f834802abe7940f2862b08297930fb"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "f65358ba6aa597492dc6aeac425a8ded86571d00b162a5e931c664f08492dfa0"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "fc7682302d1dbe39c616b526349fcf756764ed0e21ab2beb9c4ac9cc4d9cfd64c392c4c72c9c6dc6bb3bdbfd6ab1b94679c39757f398efa2617079aecc838193"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.codehaus.woodstox/woodstox-core-asl@4.4.1?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.codehaus.woodstox/woodstox-core-asl@4.4.1?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "javax.xml.stream",
+      "name": "stax-api",
+      "version": "1.0-2",
+      "description": "StAX is a standard XML processing API that allows you to stream XML data from and to your application.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7d18b63063580284c3f5734081fdc99f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d6337b0de8b25e53e81b922352fbea9f9f57ba0b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e8c70ebd76f982c9582a82ef82cf6ce14a7d58a4a4dca5cb7b7fc988c80089b7"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "a7f337735100356f72639053734506982329015693677fafd4d2ca74c4e412caae077999cb42dee2402cc641a80c8fb027deb9d2dc6c4e141d94c9184baa9dc5"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "005b7398b0a42fe2f11d2a0e65f638c4479c843bedecf691b6c1795d9f95ec8b3ff629b4e8b5d62c79082e762c4b488c"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "642519112968caa20b366e9f6e0cd7c3092d7da9dfe5cb47111e4dab7f025b6abf44c14805aa7d45df995a15b1c7525a"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "92a2eb0720aee125f29b1340a5571222bb6d2a50b441f839ec543a609845c68b"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "5be6d4726be02b83fd12db1e5c5ff871a33b097dd4b9a8d40a4466dcc194860cf76b1cbc399e4d3fe8b1e63e9b3c5f9d294fa9d85db5766b7933c346d65585b6"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "GNU General Public Library",
+            "url": "http://www.gnu.org/licenses/gpl.txt"
+          }
+        },
+        {
+          "license": {
+            "id": "CDDL-1.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/javax.xml.stream/stax-api@1.0-2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/javax.xml.stream/stax-api@1.0-2?type=jar"
+    },
+    {
+      "publisher": "fasterxml.com",
+      "group": "org.codehaus.woodstox",
+      "name": "stax2-api",
+      "version": "3.1.4",
+      "description": "tax2 API is an extension to basic Stax 1.0 API that adds significant new functionality, such as full-featured bi-direction validation interface and high-performance Typed Access API.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c08e89de601b0a78f941b2c29db565c3"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "ac19014b1e6a7c08aad07fe114af792676b685b7"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "86d7c0b775a7c9b454cc6ba61d40a8eb3b99cc129f832eb9b977a3755b4b338e"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "911e3e250c9ac9098899f12db584b83f36d91e8cca1afeef38c19952a168647dbbc88cb1cbdd5919769342ed09267263a142b12e71cab465b25daeedf2255cb7"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "83c42936c43d6d6826edea636cf315924cdf52a7201bf07f1cf87a30d2b2855088306c94f39dea55529fed0360cf563f"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "905976003ae70127f2c6142070da5736fc4a01b7a98008fefa1270fc9096691c1307e002f3b6381da462a92f2f31478e"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "308d5a1692fd0135e5af967b0b83803a2fd835429ac83401124a0357f99cbb84"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "ac3d87dab7f1e89c83f039557557536433c52a0d3201a2f514b82bb8b4f454eb9fc28b02b46a45a9caf983239612cf270085270421e4fd79eccfce0fd01f99da"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-4-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.codehaus.woodstox/stax2-api@3.1.4?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.codehaus.woodstox/stax2-api@3.1.4?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.bouncycastle",
+      "name": "bcprov-jdk15on",
+      "version": "1.54",
+      "description": "The Bouncy Castle Crypto package is a Java implementation of cryptographic algorithms. This jar contains JCE provider and lightweight API for the Bouncy Castle Cryptography APIs for JDK 1.5 to JDK 1.8.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "66a9905f98513cc5e53eabcc9af3c0fb"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "1acdedeb89f1d950d67b73d481eb7736df65eedb"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d0ae14598f9c528d2ab7bb8ed00e785a5440f692712cd362d69328aba25efb57"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "da73a0fff8844148cd1d450769a0b01c2c436887867b2623283398399bfb386ef28feb65d76e48c5aeec3c65d206aa5dc7125f61b5c87d80653e69742dab6b39"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "75d3e7c41768e26f6538836913c848f96081df09dc6828a9b557260cc37538b1d2ac503316b0c26be3af39e9112030ee"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "34f751c599e177cb87f50f32a25342588382eb69fc9895460a1b4aa79eb1e46860e47c9e05fcd7288d28733feddff3ac"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "feb9fd8408111c798186c065d8f9ab5f50f89458f95dd0d5e9ead09fb7fcb007"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "b46c6a83912044b2877e24cdeb4460e2c84e402ba8d42363e93ac09dc656a7810124e56caf212c3179a6b3574f06b111f56fbba90de8598a43f54ab0716cef30"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Bouncy Castle Licence",
+            "url": "http://www.bouncycastle.org/licence.html"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.54?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.54?type=jar"
+    },
+    {
+      "publisher": "Shibboleth Consortium",
+      "group": "org.opensaml",
+      "name": "opensaml-security-impl",
+      "version": "3.3.0",
+      "description": "Security Implementation",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "fa365f047ff1f169702024728e479fec"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "48cf37a5080ee406aef21a49045f5e1d15ea46e6"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "86f2f7fe8e66c1f114dd8a0b0e1c09046a27cc56c2e54b3301e1213c8395a684"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "840657cd9a852fdab2248328da7a68543ce9ef7a3f2603acede64d224bb8ba092d22ccf51625751725b2a07ae32f1bc5d80bb534a40a46af6ad1142d839165dc"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "c63e93d5504d8cdb4bf976cb5e0dd491c8ba48182883b61a2bd3c2cbd0b0128697d090747a3bfa2010cdcd398b9857c1"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "eeb10633639bbac0a3c0eaa9abd82bff38abe1109b2a8f596519fbc1990b8f7a8b1278c3a22ff49da9b3d19bf7c19f53"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "d2703220671ecc61cbfb572fd94bed6ed544dae49054d5a8e8db55a907bdb4c5"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "52b943e1aa348464b7f495060b6ae596cc1f61ae3bb52ba8e438ea185f7c51e06d3e212a33e250039f06d4a2dc52649587ff9cb986d21a787c27e81dee3dcf47"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.opensaml/opensaml-security-impl@3.3.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.opensaml/opensaml-security-impl@3.3.0?type=jar"
+    },
+    {
+      "publisher": "Shibboleth Consortium",
+      "group": "org.opensaml",
+      "name": "opensaml-profile-api",
+      "version": "3.3.0",
+      "description": "Profile API",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "52ae1fca37b16e3e8d900dd9f59126d8"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "e4c72301b98cf4967c49c450de7da2dbc1f6b8d0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "b2ea879a58b7299d1bcd47e311a9c82068f2f1f7be5445708a2304c812a819cc"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "a8867913e0743d1aec93f37f8c64401c427ec25ff7badd04e16bb7fb229a4ec0262e4cfa34a6c0b9415616938e28fd9d116137329ad53941efe3f244abd1a94a"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "ffc1fa49edf52fa3e94ce6762bb98ec93484109a9caac8f80f5abfcec3ad042f4a2a82a3828f74eb863eb89684f86c19"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "e36c37b1d8516b53daa84c4e34a0db0dd49cc421e7131eb777ba79069babbb8817932c69ec360f7daab11b8e70de23ba"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "95264a8e8dd626fea2141bf6ab75c240fa137abdaf91ec0003c13c0c77692ed4"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "4720b69d84d544ad94020a28fe990f60ad55c6a89b63ecd6667e0a0a2e3195615e0a4495eb199cbd3fd10c4ed4b159fd99852cf5ec0e00e6650df1fde960c6f2"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.opensaml/opensaml-profile-api@3.3.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.opensaml/opensaml-profile-api@3.3.0?type=jar"
+    },
+    {
+      "publisher": "Shibboleth Consortium",
+      "group": "org.opensaml",
+      "name": "opensaml-profile-impl",
+      "version": "3.3.0",
+      "description": "Profile Implementations",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1b05766824b89c0e1066eda47d3a2e4a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "25c28fb4ab027fcaacaa268902cffc4451ac840c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "fdaff36d7a5b69a2f976a124a355358e3573079596d34197467b16a59a3eebc5"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "44061947003491fefe893ee01ecc2c2d379bc029a6f457bc06eb09f22d1753eee6260fa35cd1ea9d6b9c569b09e87d0de3ffd93e3fe2c8e759ed99a4965e5dcc"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "9c7fe4db806bf8ce3ee5d8a68050953f7d8b3093673fc368dc50c696aac6bf4652e255c91da5b832dfa4463780ecc1c4"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "84b59147c1096b2432707c1cb780d5566c0e1c37fe8501c4fed8d94dd10df0447fdd95fecdb10c435ed5f28c57ce0cb8"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "4343b2d73944aba2096182e0f76b30014548150a1ee5cce3f7db4a55adbd81a1"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "e719d2e40fc71ee3947fbae4c1691f7e451202028b72d5b0842dba80afefbbff70a0bb27b64b39a05d47b9ce7031abc4bb3a3a63fe77dbae4234734019545c6d"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.opensaml/opensaml-profile-impl@3.3.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.opensaml/opensaml-profile-impl@3.3.0?type=jar"
+    },
+    {
+      "publisher": "Shibboleth Consortium",
+      "group": "org.opensaml",
+      "name": "opensaml-messaging-api",
+      "version": "3.3.0",
+      "description": "Messaging API",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7d67f4c124718b19291b50c4bbf60d20"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5da0ff5d28546b3af8cc1487b4717fdeb675b8c4"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "9ddc9e11a6a48e5558461c1177ad4a6227ddf913775b080ed69382019afd81d6"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "eea5ff97edd50d84ca47e4a150cc3353551588e6aa1996060801f17a313b6c4b1afca9dba4adc58b3605239631066a414a4836552a1d4097ac23d22840fa0f33"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "95a133f06115beea361e59c9df7f861f12cb863645ef4f6f1610bc3b92cf2cc47b09aa51dad373560651d7511c5e891c"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "3e6aeb65fb2b6b9b095c1bafa41f5d5ce596a069c199312119848263ed6ac3cc402c8cf00d37ccda13bf7456f781d766"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "72d3ead5e0e69901cef703167624bff0b601fce8e1ad2c1e0e0f735afcf848e5"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "1b92bec06704bda6632d287df9ebbe9526a0254a0de7a201ad22fce7b23b79a3bc62b52b07b72eff163b9eea3114cb8bf999e2d122c07c36be5cb89bc4692ab1"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.opensaml/opensaml-messaging-api@3.3.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.opensaml/opensaml-messaging-api@3.3.0?type=jar"
+    },
+    {
+      "publisher": "Shibboleth Consortium",
+      "group": "org.opensaml",
+      "name": "opensaml-messaging-impl",
+      "version": "3.3.0",
+      "description": "Messaging Implementations",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ded6296793a8fb0fc07832edafdd8509"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "38b21389971105f32099d04c6f63b4af505364ca"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "26e0df7bf48bbff5faccb9eb8f84c95cf6deaa5be96ad7c89c497166db8ce5e6"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "1218b30691825fe4c859ced59d569be64c802195b7db81d656c17060e13e4beade1b75f76acbd746eb0da797fea4cd0b6e1627022eaa25910ebacac9e2a4011b"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "00d5a6b78ddfb1330a422e51c3e9a6e6c259f577fcb6527b12f4834b2f3acacd98726aec3cbe901a10332c2227348b29"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "65bf8fc246a9089c419b9f2309261978e69b32d932bf21748534f8e088587c47c4cf585cbc4f0d5cd4f22ab86c9b9df0"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "4f284848a1aaab8fd0cf474ddf49db16c1519c5fd13d858f453c66c7b4df8511"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "57760eda202403347731ab39e5929b9bf38ab0ac74ac6fdd124d59a3ef5a7838e0573758541720ee8907938527aa6c4cace98e9f565118ec9a5aa631bd35b230"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.opensaml/opensaml-messaging-impl@3.3.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.opensaml/opensaml-messaging-impl@3.3.0?type=jar"
+    },
+    {
+      "publisher": "Shibboleth Consortium",
+      "group": "org.opensaml",
+      "name": "opensaml-xmlsec-impl",
+      "version": "3.3.0",
+      "description": "XML Security Implementation",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "99cc0c6a2d081654faafb9820fe49777"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "569ae8fc7c84817c5324e9f9b7958adf700a94c1"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8577d3833ac7092017c273ae083829ee2876bc9863b1995eebc46e5ecf5e441a"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "5ba25db4bb92ac95340c7880ea9374ccc758684f026d60c82467ad8d249644d618bb5cef20b468bd200b7eefb517bd9990a99362cb7d391318d388649c1bf67e"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "da3730f257edc6462a4960a0d9d8fa273c54176c8150ae81c4fb6e4b3bcc5f07dbbb698f4b0125812839d5258b546edc"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "282ef749f8bef81506210d9ca033b1627d218590a93987730d20d2142991cb77fd1a96a35527ccf2bbcac5a3896fecf2"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "01600eda60fb622888323bad93174e1788d1721ba6beb8734e38679a92636a4a"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "43a97dea1e2c8cda3adbccfd7f439ba4408ab8027888c25408715265b19ebec27c4d6b66fe275f09dd26cd2074a2b3a19ed113675bd29750e3f2926f56cf1029"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.opensaml/opensaml-xmlsec-impl@3.3.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.opensaml/opensaml-xmlsec-impl@3.3.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.cryptacular",
+      "name": "cryptacular",
+      "version": "1.1.0",
+      "description": "The spectacular complement to the Bouncy Castle crypto API for Java.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "df816bdf31b8c9f40c08eabcf1006443"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "eabbba7a9379d531000debfba3c983f5071f7e60"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f3430ba9cfe23016e2e106ca7631696fc9e335739d62c2935a54fb176d8dcedc"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "becfe5bb893f81cf9d9861e83a849fa1c05463f36a18bd95c6c2be1dd7eec2d482e3339392989b688a77ac9a7af561d47324fcd31bc6a4fbd8e5b05f1752d075"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "189f42524f1b473363f136788b7007d3b00f2f08c7fc9b3cff924d6e51dc11de67f011ec4eda41b05826542497bab67e"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "ab4ff869b85b0f331de6ee85cb99cda174fd2799d53462ddcd9ec48a3ed16f39d6417a79e1a1e88e0a0bc398bb1a4317"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "f507e89c279bb025ffbab591f96a4dae2eba1b1bdb2680d35114091e10d62809"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "c3153871f38c8aef2086262c8b7239e2ae987abb046425798189aef3d9909741ec157f6a1b2b80b30ea859ab15497dc884fe061030a45c4acc326526d14a9b15"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "name": "GNU Lesser General Public License",
+            "url": "http://www.gnu.org/licenses/lgpl-3.0.txt"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.cryptacular/cryptacular@1.1.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.cryptacular/cryptacular@1.1.0?type=jar"
+    },
+    {
+      "publisher": "Joda.org",
+      "group": "joda-time",
+      "name": "joda-time",
+      "version": "2.9.2",
+      "description": "Date and time library to replace JDK date handling",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "32a794b6a820daf3fad92e59988df64c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "36d6e77a419cb455e6fd5909f6f96b168e21e9d0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0be5c40e8cdce9ec0643d76be99f276db17c45d7616a217fd1b19b7ef73ca7b1"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "52bf64e32ae5303ecf78510f78acfdce46b1654214a106f4d92f7c8e09ab4214790567198dd4c54b0f6e2b75765ad0c7b4a2d2cb3483e2782f16faed5546a8da"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "fe4d61fa8c2ae6bfe94b897fb100a23678bbd172b5c939531197c5566c5836f9a719484b5cf2f70960996bd397c0025c"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "4aaa49db59997ce580609dfb0142ed91656cb2f8db667e9fc7d8e206f4480e379601c8c16ee3e7a8870048b7da8209f0"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "361583e31c9add8f66af3220979a7a96aea0f2886644cd40e15e90ac5da0ca24"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "047292bca529cf8e9702041982348af816dbcec95917df377197eb22d798c3ac3d09a70591d21cea16a4e5e55ec491c74e0a9d062994303a7715548a9b122454"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/joda-time/joda-time@2.9.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/joda-time/joda-time@2.9.2?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "xalan",
+      "name": "xalan",
+      "version": "2.7.2",
+      "description": "Xalan-Java is an XSLT processor for transforming XML documents into HTML, text, or other XML document types. It implements XSL Transformations (XSLT) Version 1.0 and XML Path Language (XPath) Version 1.0 and can be used from the command line, in an applet or a servlet, or as a module in other program.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6aa6607802502c8016b676f25f8e4873"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d55d3f02a56ec4c25695fe67e1334ff8c2ecea23"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "a44bd80e82cb0f4cfac0dac8575746223802514e3cec9dc75235bc0de646af14"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "00f859c5bd65f6dc91e396ce91fe2f6d30b2354d6b419cd9ea96984c5403e5cd1342bb9362b0ae1f2792612f0df731c4f7ac92f16a825bb7e22089c27a129c6c"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "f107b40321720128c82aa3cdef232c8dc393dc2023de47c9e4c6b16c49caa1fc72f7390fe32e9ae3f3668d30df2125a3"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "84aab60e28c50375b8fa20daf3c6111fcd8951053946178d8816c4be43f2d5bdfc7f1942e19babed58acd5970baa1c5f"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "f2a34f1bf6974b33a210092e37ccebc7b546312e7433e996df9d94376ef844d6"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "ba5477ac480a197a9bfd1e3a5f9ac619e0604fee2643c80a82e34120ea8234d634af57bdfc2782973a8fb43bb941737855731717488d202fbc3e74021e48dad3"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/xalan/xalan@2.7.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/xalan/xalan@2.7.2?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "xalan",
+      "name": "serializer",
+      "version": "2.7.2",
+      "description": "Serializer to write out XML, HTML etc. as a stream of characters from an input DOM or from input SAX events.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e8325763fd4235f174ab7b72ed815db1"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "24247f3bb052ee068971393bdb83e04512bb1c3c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e8f5b4340d3b12a0cfa44ac2db4be4e0639e479ae847df04c4ed8b521734bb4a"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "884d865865858a46306a3680df69f3f0efa0df1313706b54e6900d36af21e17cb6828f5a6bac551c59f7f80bdd1cb64c3fdbde44e213519c4af87969e9e70774"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "9cc49e92c8f9c68db5caec6e9e550e880c7a3c73da01e958a023794ec8a8ce19a3561344b9a313444e15a5765403660d"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "fd973e909eac546627173f53cb12c6884c2138fd7f21425fb68f9228c4145b0448e18bfbc9bb296ecb0c83da253340c5"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "e6d8521a88ae1b3d0af623ebc54e5a041758fb545fd79936cd151550f72cdadc"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "0b1efb82b2bab01389465d0d58b7119a15c328c74516fed469b44841ccd2e14d08bc370d4a4b2292c290867495b7f4f3bf392039fd1ad2f58875dc6882bd7f13"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/xalan/serializer@2.7.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/xalan/serializer@2.7.2?type=jar"
+    },
+    {
+      "publisher": "Apache Software Foundation",
+      "group": "xml-apis",
+      "name": "xml-apis",
+      "version": "1.3.04",
+      "description": "xml-commons provides an Apache-hosted set of DOM, SAX, and JAXP interfaces for use in other xml-based projects. Our hope is that we can standardize on both a common version and packaging scheme for these critical XML standards interfaces to make the lives of both our developers and users easier. The External Components portion of xml-commons contains interfaces that are defined by external standards organizations. For DOM, that's the W3C; for SAX it's David Megginson and sax.sourceforge.net; for JAXP it's Sun.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "9ae9c29e4497fc35a3eade1e6dd0bbeb"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "90b215f48fe42776c8c7f6e3509ec54e84fd65ef"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d404aa881eb9c5f7a4fb546e84ea11506cd417a72b5972e88eff17f43f9f8a64"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "1086a52924add2406e0b4ec7219a8783ac20e02a32a7a2461efbf092f0070501f7cade9c0588907c403352f1a48f80b950e6d40b2e4e3e9eb886e7db4e97bdec"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "f903cd32c64e2ebb042e4b0b2502ccc19a759c471067a232cdce33c0c83d26db578ed0d201fada9240b9bb384b48cd48"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "5cf660101b63ceb31d2344d1caa323c16c92f3ad8fb71795498c1a13166a1f5565297a7d58f0f6ac743be0bb523322e8"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "ca3fe250c6bd2d90ffc0b9cf73d198ba3aeb48b081d903497c32007806b686c8"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "36269b4466c9b6225c6520b62fa4cd3c09ef3154036f77e0db8b8331764376789ed5f3a9fe2f633245e5636afcb365c4815bea8edaeb2fdcc98e8d690910d7fa"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/xml-apis/xml-apis@1.3.04?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/xml-apis/xml-apis@1.3.04?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "org.apache.velocity",
+      "name": "velocity",
+      "version": "1.7",
+      "description": "Apache Velocity is a general purpose template engine.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "3692dd72f8367cb35fb6280dc2916725"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "2ceb567b8f3f21118ecdec129fe1271dbc09aa7a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ec92dae810034f4b46dbb16ef4364a4013b0efb24a8c5dd67435cae46a290d8e"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "e521785d947cae1a02070b26a43d235b6319439a6364c58266d3f9c458f9a099406c10aab5f51c5db5ba541e88322cb35203c6758b4b8bb65f9539a345da9a04"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "94eb2247eb326dfc5f39a6d5bb71f6402531dad128281db32cad84d5571fb5fd4d07bdcdddb6fde91576021fe5faaa2d"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "32292f15259b5a1cfee52be3c0e7ca08b778e7b4d40b07136d836f726bb9893075e3444dcefe7ab7ff0f1284092b138c"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "b3e19d65650a20bf773683b7aadb92edd588237d3c8a6600dcfe25fd22098535"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "00ed4a489b0372cac0e677df29b07e7c21c54aec229833c92b92bdb16da9178a94826fe665154f1e6ea22e2c1fdce4aa847fa40b75928dc82a87b68f6bd6aec6"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.velocity/velocity@1.7?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.velocity/velocity@1.7?type=jar"
+    },
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "commons-lang",
+      "name": "commons-lang",
+      "version": "2.4",
+      "description": "Commons Lang, a package of Java utility classes for the classes that are in java.lang's hierarchy, or are considered to be so standard as to justify existence in java.lang.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "237a8e845441bad2e535c57d985c8204"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "16313e02a793435009f1e458fa4af5d879f6fb11"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2c73b940c91250bc98346926270f13a6a10bb6e29d2c9316a70d134e382c873e"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "ae35b761d16f4327cdb6fda16789166fc67020efd71fd2cc3395b97444f439dfcc7eee948a3efd3b02440416caeb873417d95db6a2b16f4ef198de9d1afbc045"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "aef894734c328ec53b22c4efa33759c6ddb888093498411a439eb9a5494a8529beaa71cde0fd1d9ca526812d748c3a88"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "970e56888f04a30878e6d6b7ec895060f61eeb6f745a8a58beb2ab94871e45845a468443629c1d1dc5ed6b8eecd5f6e9"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "c6b19be6e3d3bb980cd6ecb6c0e2daaa506200d6e4e8a2a3cf29748581406971"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "c1cb8ff6c49109acb57dbc0ae2a21e0a689fc34ddf01521ced8c4ae93355b55527ced59c6b3f324b44cf4b24ced5f063815046f9bd62c44e3ef41417d8eff972"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/commons-lang/commons-lang@2.4?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/commons-lang/commons-lang@2.4?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "commons-collections",
+      "name": "commons-collections",
+      "version": "3.2.2",
+      "description": "Types that extend and augment the Java Collections Framework.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f54a8510f834a1a57166970bfc982e94"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "8ad72fe39fa8c91eaaf12aadb21e0c3661fe26d5"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "eeeae917917144a68a741d4c0dff66aa5c5c5fd85593ff217bced3fc8ca783b8"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "51c72f9aca7726f3c387095e66be85a6df97c74b00a25434b89188c1b8eab6e2b55accf7b9bd412430d22bd09324dec076e300b3d1fa39fccad471f0f2a3da16"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "dd4e99b3314bd3c1a1ee26296615d9e44dadf7a1f8a7bbba44fb95121803d331e36d4cca4260e7609af78a47ba3e4073"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "8ce03528e4a6e95c44283b56eca87e6a6d3bf1363411a55b538f4f9110cf7470581ea5c73925e877ddab08dba0603f40"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "fd3d6134b5f07077b82ccf93d148dacf7c4ce5c971209510edd0e77e3e38c19e"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "c2a523916fb7c7d55a05d5e3d9e9b33000733f4b20a71be174e4e093e3f06ea78ad831edd1505527da7388105f8647efb7d5666ba852c90b4e2d5bb74256efbc"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/commons-collections/commons-collections@3.2.2?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/commons-collections/commons-collections@3.2.2?type=jar"
+    },
+    {
+      "publisher": "QOS.ch",
+      "group": "org.slf4j",
+      "name": "jcl-over-slf4j",
+      "version": "1.7.25",
+      "description": "JCL 1.2 implemented over SLF4J",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "56b22adc639b09b2e917f42d68b26600"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f8c32b13ff142a513eeb5b6330b1588dcb2c0461"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5e938457e79efcbfb3ab64bc29c43ec6c3b95fffcda3c155f4a86cc320c11e14"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "0a703864b269de6f7bc98df0fa98aa943cc327a4ca2915899d460e4a071fcc3fbe70957eb91b740cc935d0960b3d98f30c54a0a4019d7ae8c6d50f51edb8d149"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "6928492388b56628cf4a2b8411d4032d179a9cf318b03fb4bade1ef690e75813354482a68d667f64d9f2c7dad57ff9db"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "b02c290871df4d411761548ed6d976adcc7a56df251b5facef6f9de1e31cf6e62d40e002c35b301827b60a65b65d11da"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "6ecd86745e9cb7165c98725e9d17ceaedeafd90ac42c90ca2ed102900f7fc20f"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "dffaa6188e8fb42a235fa9bd9caf4ca4c2c9f8545763d673552a3746ef7bd51ec0f2270de2e0cca21b290a01d01004ff0baaecef4ffcdb616fbec363cc8b9d22"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.25?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.25?type=jar"
+    },
+    {
+      "publisher": "Spring IO",
+      "group": "org.springframework",
+      "name": "spring-core",
+      "version": "4.3.7.RELEASE",
+      "description": "Spring Core",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "bfe2809bd044dc97cfca5db00e8ab1e4"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "54fa2db94cc7222edc90ec71354e47cd1dc07f7b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "fff510e18dbe8f3bb9eec0dcfd253615b820be9f15e51b788db2440b05384aaa"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "7c706c5f0466bbb77a94761188cde3960e13d5008cd397653b0e8709af46d5e0b78d69ddc8e74fe48a6769585900977656f10aae6ae3f85090626a944fb3e926"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "d81cb172da4bd65fc056497abc64f0b216ad120e43a31d9774494ea3750786b185c1187b643f5ea9e6e17b85cfddb7a9"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "ccc5f79ea80e63e96f86e2219d7351fcb9eb607124c521cb2b7468494a53afb488581d774020fac4356851f321b03a5b"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "df143b9f918a74d67d56e8579911c041b995521c11cfaeaf153c9f602c308665"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "521bb74355dcf2a64e81b681fa3e2b7397313ac3ae6117fd8052cbde261421e21e0b9e4c22e1866741f4a86048c449540fc62d7cbe7688257563b471b00c202c"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.springframework/spring-core@4.3.7.RELEASE?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/org.springframework/spring-core@4.3.7.RELEASE?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "commons-logging",
+      "name": "commons-logging",
+      "version": "1.2",
+      "description": "Apache Commons Logging is a thin adapter allowing configurable bridging to other, well known logging systems.",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "040b4b4d8eac886f6b4a2a3bd2f31b00"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "4bfc12adfe4842bf07b657f0369c4cb522955686"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "daddea1ea0be0f56978ab3006b8ac92834afeefbd9b7e4e6316fca57df0fa636"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "ed00dbfabd9ae00efa26dd400983601d076fe36408b7d6520084b447e5d1fa527ce65bd6afdcb58506c3a808323d28e88f26cb99c6f5db9ff64f6525ecdfa557"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "ac20720d7156131478205f1b454395abf84cfc8da2f163301af32f63bd3c4764bd26cb54ed53800f33193ae591f3ce9c"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "628eb4407e95dca84da1a06b08a6d9b832a49de8472b1b217e8607f08efeeed18b996232d64dd07f03e78e0e3bb4b078"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "9aab62deccf156ee6e324c925dfc30ecb53e8465802863a551901a461424e807"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "3fd76857f6d20c03799537cc961c1c4ddf1c375c6c192fb982363e3b9397ba138b77f24ef38b4202f44e37586789c0320e4de18fdadd2772304fd14a9b26d552"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/commons-logging/commons-logging@1.2?type=jar",
+      "type": "framework",
+      "bom-ref": "pkg:maven/commons-logging/commons-logging@1.2?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.jdbi",
+      "name": "jdbi",
+      "version": "2.78",
+      "description": "jDBI is designed to provide convenient tabular data access in Java(tm). It uses the Java collections framework for query results, provides a convenient means of externalizing sql statements, and provides named parameter support for any database being used.",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "ea7256f4877d929815d317c3f918de7e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "7281bb97a89ec38db81a901a3c07ed7204efe828"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "a833944751416b95a397768c530b6796fd22fe01ff3d56f44ab80c2087096572"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "0699d1cee041bbb7f2e9857f0d4265e55af3c93e62c1d10090fa3472a3af4f052c4b6c1431eca53bf2e2ddb1df1358ac29fba6776fb0406a2c3edbe30fe73607"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "b421df6a4952a9942ea169202bf56527689f187d63c7a1cc604043aac6383086b6710994143bb72637c5a291910d1edb"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "f128930891a9ff6f73ac6cc2493011300bfc9e8e2e3e275b52c6cf91b8f35db7d88ddb390ee3ef28263f5a1a825d7527"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "85bab22465bd6c4128b3a3805184b780dd41c6984d6e056d7ec22b904b94649b"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "0d3f050c4f71bfab5404ac1674306bd837ff7710b9b04893dcfe88baa3d0d3f647ee515c3b0a3159d4f6d3791f187927dabed54f05fcfa3b42bd4f0bbae93586"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.jdbi/jdbi@2.78?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.jdbi/jdbi@2.78?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.pac4j",
+      "name": "pac4j-core",
+      "version": "3.0.0",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:maven/org.pac4j/pac4j-core@3.0.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.pac4j/pac4j-core@3.0.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.pac4j",
+      "name": "pac4j-cas",
+      "version": "3.0.0",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:maven/org.pac4j/pac4j-cas@3.0.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.pac4j/pac4j-cas@3.0.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.pac4j",
+      "name": "pac4j-saml",
+      "version": "3.0.0",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:maven/org.pac4j/pac4j-saml@3.0.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.pac4j/pac4j-saml@3.0.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.pac4j",
+      "name": "pac4j-oauth",
+      "version": "3.0.0",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:maven/org.pac4j/pac4j-oauth@3.0.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.pac4j/pac4j-oauth@3.0.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.pac4j",
+      "name": "pac4j-oidc",
+      "version": "3.0.0",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:maven/org.pac4j/pac4j-oidc@3.0.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.pac4j/pac4j-oidc@3.0.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.pac4j",
+      "name": "pac4j-ldap",
+      "version": "3.0.0",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:maven/org.pac4j/pac4j-ldap@3.0.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.pac4j/pac4j-ldap@3.0.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.pac4j",
+      "name": "pac4j-http",
+      "version": "3.0.0",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:maven/org.pac4j/pac4j-http@3.0.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.pac4j/pac4j-http@3.0.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.pac4j",
+      "name": "pac4j-sql",
+      "version": "3.0.0",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:maven/org.pac4j/pac4j-sql@3.0.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.pac4j/pac4j-sql@3.0.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.pac4j",
+      "name": "pac4j-config",
+      "version": "3.0.0",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:maven/org.pac4j/pac4j-config@3.0.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.pac4j/pac4j-config@3.0.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.pac4j",
+      "name": "pac4j-openid",
+      "version": "3.0.0",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:maven/org.pac4j/pac4j-openid@3.0.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.pac4j/pac4j-openid@3.0.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.pac4j",
+      "name": "pac4j-gae",
+      "version": "3.0.0",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:maven/org.pac4j/pac4j-gae@3.0.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.pac4j/pac4j-gae@3.0.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.pac4j",
+      "name": "pac4j-jwt",
+      "version": "3.0.0",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:maven/org.pac4j/pac4j-jwt@3.0.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.pac4j/pac4j-jwt@3.0.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.pac4j",
+      "name": "pac4j-mongo",
+      "version": "3.0.0",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:maven/org.pac4j/pac4j-mongo@3.0.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.pac4j/pac4j-mongo@3.0.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.pac4j",
+      "name": "pac4j-couch",
+      "version": "3.0.0",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:maven/org.pac4j/pac4j-couch@3.0.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.pac4j/pac4j-couch@3.0.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.pac4j",
+      "name": "pac4j-kerberos",
+      "version": "3.0.0",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:maven/org.pac4j/pac4j-kerberos@3.0.0?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.pac4j/pac4j-kerberos@3.0.0?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "org.foo.bar",
+      "name": "always",
+      "version": "1.0.0-SNAPSHOT",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:maven/org.foo.bar/always@1.0.0-SNAPSHOT?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/org.foo.bar/always@1.0.0-SNAPSHOT?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "com.infradna.tool",
+      "name": "bridge-method-annotation",
+      "version": "1.13",
+      "description": "",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "2ee1c4c795c0c749988760d3f3b14ff5"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "18cdce50cde6f54ee5390d0907384f72183ff0fe"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2bc0d11e078c6ee0c0f9a781aa12d9f2d78807e1c026952f834ca77cfaa1dd04"
+        },
+        {
+          "alg": "SHA-512",
+          "content": "aa24c3cf33b643eb767e6b2ff0b19510648172c20c9ff97d56fc3613b72e447fba94dd176ed59c04b0df7ff8aaba85cb78aa6c6fe71e514f3d5c8af81a67724e"
+        },
+        {
+          "alg": "SHA-384",
+          "content": "d6eac43bd9d96a6313dab761ab91eac0f66ae62b3b58be46840525fc479ff9a3429f4bdaf9001450409af9805d2f20f0"
+        },
+        {
+          "alg": "SHA3-384",
+          "content": "3b30433fbd4a3ad2d56ef1a0a372df65a22dbd94f5145283827725b99cdccaf8781e3fb10aebdc5a809bc07412f1eece"
+        },
+        {
+          "alg": "SHA3-256",
+          "content": "63dbf603278967950368fa6226243f56ccd5598dfeb7bd324dcf7952a28ba094"
+        },
+        {
+          "alg": "SHA3-512",
+          "content": "65e6fc98d7d038bd74132c8e82aaabe7986424013aa48abd09785535c4ee0a416aa6d66bf7b3dc8798c984031ce04797ca03f010f4175ce497fbf98376b20b27"
+        }
+      ],
+      "licenses": [],
+      "purl": "pkg:maven/com.infradna.tool/bridge-method-annotation@1.13?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/com.infradna.tool/bridge-method-annotation@1.13?type=jar"
+    },
+    {
+      "publisher": "",
+      "group": "actions",
+      "name": "checkout",
+      "version": "c85c95e3d7251135ab7dc9ce3241c5835cc595a9",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:github/actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9",
+      "type": "application",
+      "bom-ref": "pkg:github/actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9"
+    },
+    {
+      "publisher": "",
+      "group": "actions",
+      "name": "setup-java",
+      "version": "5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:github/actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2",
+      "type": "application",
+      "bom-ref": "pkg:github/actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2"
+    },
+    {
+      "publisher": "",
+      "group": "actions",
+      "name": "setup-go",
+      "version": "fac708d6674e30b6ba41289acaab6d4b75aa0753",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:github/actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753",
+      "type": "application",
+      "bom-ref": "pkg:github/actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753"
+    },
+    {
+      "publisher": "",
+      "group": "jreleaser",
+      "name": "release-action",
+      "version": "0b198089c53ad2aef0d2bff6b5e6061ead2bbb90",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:github/jreleaser/release-action@0b198089c53ad2aef0d2bff6b5e6061ead2bbb90",
+      "type": "library",
+      "bom-ref": "pkg:github/jreleaser/release-action@0b198089c53ad2aef0d2bff6b5e6061ead2bbb90"
+    },
+    {
+      "publisher": "",
+      "group": "actions",
+      "name": "upload-artifact",
+      "version": "0b7f8abb1508181956e8e162db84b466c27e18ce",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:github/actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce",
+      "type": "application",
+      "bom-ref": "pkg:github/actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce"
+    },
+    {
+      "publisher": "",
+      "group": "JetBrains",
+      "name": "qodana-action",
+      "version": "54d3fc653c515607d6b1599201a383e9e07649b1",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:github/JetBrains/qodana-action@54d3fc653c515607d6b1599201a383e9e07649b1",
+      "type": "library",
+      "bom-ref": "pkg:github/JetBrains/qodana-action@54d3fc653c515607d6b1599201a383e9e07649b1"
+    },
+    {
+      "publisher": "",
+      "group": "",
+      "name": "github/codeql-action/upload-sarif",
+      "version": "46ed16ded91731b2df79a2893d3aea8e9f03b5c4",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:github/github/codeql-action/upload-sarif@46ed16ded91731b2df79a2893d3aea8e9f03b5c4",
+      "type": "library",
+      "bom-ref": "pkg:github/github/codeql-action/upload-sarif@46ed16ded91731b2df79a2893d3aea8e9f03b5c4"
+    },
+    {
+      "publisher": "",
+      "group": "actions",
+      "name": "cache",
+      "version": "88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:github/actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8",
+      "type": "application",
+      "bom-ref": "pkg:github/actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8"
+    },
+    {
+      "publisher": "",
+      "group": "slsa-framework",
+      "name": "github-actions-demo",
+      "version": "9474e92bbf825d5b4b46810fc9367dfc73429a2a",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:github/slsa-framework/github-actions-demo@9474e92bbf825d5b4b46810fc9367dfc73429a2a",
+      "type": "library",
+      "bom-ref": "pkg:github/slsa-framework/github-actions-demo@9474e92bbf825d5b4b46810fc9367dfc73429a2a"
+    },
+    {
+      "publisher": "",
+      "group": "step-security",
+      "name": "harden-runner",
+      "version": "55d479fb1c5bcad5a4f9099a5d9f37c8857b2845",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:github/step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845",
+      "type": "library",
+      "bom-ref": "pkg:github/step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845"
+    },
+    {
+      "publisher": "",
+      "group": "ossf",
+      "name": "scorecard-action",
+      "version": "08b4669551908b1024bb425080c797723083c031",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:github/ossf/scorecard-action@08b4669551908b1024bb425080c797723083c031",
+      "type": "library",
+      "bom-ref": "pkg:github/ossf/scorecard-action@08b4669551908b1024bb425080c797723083c031"
+    },
+    {
+      "publisher": "",
+      "group": "oracle-actions",
+      "name": "setup-java",
+      "version": "2c4df2930e35870536667f383d87f1246fbe613f",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:github/oracle-actions/setup-java@2c4df2930e35870536667f383d87f1246fbe613f",
+      "type": "library",
+      "bom-ref": "pkg:github/oracle-actions/setup-java@2c4df2930e35870536667f383d87f1246fbe613f"
+    },
+    {
+      "publisher": "",
+      "group": "actions",
+      "name": "setup-python",
+      "version": "bd6b4b6205c4dbad673328db7b31b7fab9e241c0",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:github/actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0",
+      "type": "application",
+      "bom-ref": "pkg:github/actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0"
+    },
+    {
+      "publisher": "",
+      "group": "stCarolas",
+      "name": "setup-maven",
+      "version": "07fbbe97d97ef44336b7382563d66743297e442f",
+      "description": "",
+      "licenses": [],
+      "purl": "pkg:github/stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f",
+      "type": "library",
+      "bom-ref": "pkg:github/stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f"
+    }
+  ],
+  "services": [],
+  "dependencies": [
+    {
+      "ref": "pkg:maven/fr.inria.gforge.spoon/spoon-control-flow@0.0.2-SNAPSHOT?type=jar",
+      "dependsOn": [
+        "pkg:maven/fr.inria.gforge.spoon/spoon-core@10.3.0?type=jar",
+        "pkg:maven/org.jgrapht/jgrapht-core@0.9.2?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/fr.inria.gforge.spoon/spoon-core@10.3.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.eclipse.jdt/org.eclipse.jdt.core@3.32.0?type=jar",
+        "pkg:maven/com.martiansoftware/jsap@2.1?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar",
+        "pkg:maven/commons-io/commons-io@2.11.0?type=jar",
+        "pkg:maven/org.apache.maven/maven-model@4.0.0-alpha-7?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.12.0?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.2?type=jar",
+        "pkg:maven/org.apache.commons/commons-compress@1.22?type=jar",
+        "pkg:maven/org.apache.maven.shared/maven-invoker@3.2.0?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.eclipse.jdt/org.eclipse.jdt.core@3.32.0?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.martiansoftware/jsap@2.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/commons-io/commons-io@2.11.0?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.maven/maven-model@4.0.0-alpha-7?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.apache.maven/maven-api-model@4.0.0-alpha-7?type=jar",
+        "pkg:maven/org.apache.maven/maven-xml-impl@4.0.0-alpha-7?type=jar",
+        "pkg:maven/org.codehaus.plexus/plexus-xml@4.0.1?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.apache.maven/maven-api-model@4.0.0-alpha-7?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.apache.maven/maven-api-xml@4.0.0-alpha-7?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.apache.maven/maven-api-xml@4.0.0-alpha-7?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.apache.maven/maven-api-meta@4.0.0-alpha-7?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.apache.maven/maven-api-meta@4.0.0-alpha-7?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.maven/maven-xml-impl@4.0.0-alpha-7?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.apache.maven/maven-api-xml@4.0.0-alpha-7?type=jar",
+        "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.9.0.M2?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.9.0.M2?type=jar",
+      "dependsOn": [
+        "pkg:maven/javax.annotation/javax.annotation-api@1.2?type=jar",
+        "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.inject@0.9.0.M2?type=jar",
+        "pkg:maven/org.codehaus.plexus/plexus-component-annotations@2.1.0?type=jar",
+        "pkg:maven/org.codehaus.plexus/plexus-classworlds@2.6.0?type=jar",
+        "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/javax.annotation/javax.annotation-api@1.2?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.inject@0.9.0.M2?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.codehaus.plexus/plexus-component-annotations@2.1.0?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.codehaus.plexus/plexus-classworlds@2.6.0?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.codehaus.plexus/plexus-xml@4.0.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.commons/commons-lang3@3.12.0?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.2?type=jar",
+      "dependsOn": [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.14.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.14.2?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.14.2?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.14.2?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.commons/commons-compress@1.22?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.maven.shared/maven-invoker@3.2.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.apache.maven.shared/maven-shared-utils@3.3.4?type=jar",
+        "pkg:maven/javax.inject/javax.inject@1?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.apache.maven.shared/maven-shared-utils@3.3.4?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/javax.inject/javax.inject@1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.jgrapht/jgrapht-core@0.9.2?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/se.kth.castor/helloworld@1.0-SNAPSHOT?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.json/json@20090211?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.json/json@20090211?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/fr.inria.gforge.spoon/spoon-decompiler@0.2.0-SNAPSHOT?type=jar",
+      "dependsOn": [
+        "pkg:maven/fr.inria.gforge.spoon/spoon-core@10.3.0?type=jar",
+        "pkg:maven/org.jboss.windup.decompiler.fernflower/fernflower@2.5.0.Final?type=jar",
+        "pkg:maven/org.bitbucket.mstrobel/procyon-compilertools@0.6.0?type=jar",
+        "pkg:maven/org.benf/cfr@0.152?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.jboss.windup.decompiler.fernflower/fernflower@2.5.0.Final?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.bitbucket.mstrobel/procyon-compilertools@0.6.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.bitbucket.mstrobel/procyon-core@0.6.0?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.bitbucket.mstrobel/procyon-core@0.6.0?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.benf/cfr@0.152?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/fr.inria.gforge.spoon/spoon-javadoc@10.4.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/fr.inria.gforge.spoon/spoon-core@10.4.0?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/fr.inria.gforge.spoon/spoon-core@10.4.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.eclipse.jdt/org.eclipse.jdt.core@3.33.0?type=jar",
+        "pkg:maven/com.martiansoftware/jsap@2.1?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar",
+        "pkg:maven/commons-io/commons-io@2.13.0?type=jar",
+        "pkg:maven/org.apache.maven/maven-model@3.6.0?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.12.0?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.15.2?type=jar",
+        "pkg:maven/org.apache.commons/commons-compress@1.23.0?type=jar",
+        "pkg:maven/org.apache.maven.shared/maven-invoker@3.2.0?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.eclipse.jdt/org.eclipse.jdt.core@3.33.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.eclipse.jdt/ecj@3.33.0?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.eclipse.jdt/ecj@3.33.0?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/commons-io/commons-io@2.13.0?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.maven/maven-model@3.6.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.codehaus.plexus/plexus-utils@3.1.0?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.codehaus.plexus/plexus-utils@3.1.0?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.15.2?type=jar",
+      "dependsOn": [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.15.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.15.2?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.15.2?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.15.2?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.commons/commons-compress@1.23.0?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/fr.inria.gforge.spoon/spoon-pom@10.4.0?type=pom",
+      "dependsOn": [
+        "pkg:maven/fr.inria.gforge.spoon/spoon-core@10.4.0?type=jar",
+        "pkg:maven/fr.inria.gforge.spoon/spoon-javadoc@10.4.0?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/fr.inria.gforge.spoon/spoon-smpl@0.0.1?type=jar",
+      "dependsOn": [
+        "pkg:maven/fr.inria.gforge.spoon/spoon-core@10.3.0?type=jar",
+        "pkg:maven/fr.inria.gforge.spoon/spoon-control-flow@0.0.2-SNAPSHOT?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/fr.inria.gforge.spoon/visualisation@1.1?type=jar",
+      "dependsOn": [
+        "pkg:maven/io.github.interacto/interacto-javafx@4.3.1?type=jar",
+        "pkg:maven/fr.inria.gforge.spoon/spoon-core@10.3.0?type=jar",
+        "pkg:maven/org.openjfx/javafx-base@11.0.2?type=jar",
+        "pkg:maven/org.openjfx/javafx-graphics@11.0.2?type=jar",
+        "pkg:maven/org.openjfx/javafx-controls@11.0.2?type=jar",
+        "pkg:maven/org.openjfx/javafx-fxml@11.0.2?type=jar",
+        "pkg:maven/org.jetbrains/annotations@24.0.1?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.github.interacto/interacto-javafx@4.3.1?type=jar",
+      "dependsOn": [
+        "pkg:maven/io.github.interacto/interacto-java-api@4.3.1?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.github.interacto/interacto-java-api@4.3.1?type=jar",
+      "dependsOn": [
+        "pkg:maven/io.reactivex.rxjava2/rxjava@2.2.4?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.reactivex.rxjava2/rxjava@2.2.4?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.reactivestreams/reactive-streams@1.0.2?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.reactivestreams/reactive-streams@1.0.2?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.openjfx/javafx-base@11.0.2?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.openjfx/javafx-base@11.0.2?classifier=linux&type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.openjfx/javafx-base@11.0.2?classifier=linux&type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.openjfx/javafx-graphics@11.0.2?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.openjfx/javafx-graphics@11.0.2?classifier=linux&type=jar",
+        "pkg:maven/org.openjfx/javafx-base@11.0.2?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.openjfx/javafx-graphics@11.0.2?classifier=linux&type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.openjfx/javafx-controls@11.0.2?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.openjfx/javafx-controls@11.0.2?classifier=linux&type=jar",
+        "pkg:maven/org.openjfx/javafx-graphics@11.0.2?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.openjfx/javafx-controls@11.0.2?classifier=linux&type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.openjfx/javafx-fxml@11.0.2?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.openjfx/javafx-fxml@11.0.2?classifier=linux&type=jar",
+        "pkg:maven/org.openjfx/javafx-controls@11.0.2?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.openjfx/javafx-fxml@11.0.2?classifier=linux&type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.jetbrains/annotations@24.0.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.foo.bar/foobar@1.0.0-SNAPSHOT?type=jar",
+      "dependsOn": [
+        "pkg:maven/com.infradna.tool/bridge-method-annotation@1.13?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/pt.ulisboa.tecnico.socialsoftware/quizzes-tutor-backend@0.0.1-SNAPSHOT?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-data-jpa@2.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.2.5.RELEASE?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-devtools@2.2.2.RELEASE?type=jar",
+        "pkg:maven/javax.xml.bind/jaxb-api@2.4.0-b180830.0359?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-configuration-processor@2.2.2.RELEASE?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.10.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-security@2.2.2.RELEASE?type=jar",
+        "pkg:maven/org.postgresql/postgresql@42.2.8?type=jar",
+        "pkg:maven/io.springfox/springfox-swagger2@2.9.2?type=jar",
+        "pkg:maven/io.springfox/springfox-swagger-ui@2.9.2?type=jar",
+        "pkg:maven/org.fenixedu/feaf4j-api@2.3.1?type=jar",
+        "pkg:maven/org.fenixedu/feaf4j-okhttp@2.3.1?type=jar",
+        "pkg:maven/org.springframework.retry/spring-retry@1.2.5.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-aspects@5.2.2.RELEASE?type=jar",
+        "pkg:maven/io.jsonwebtoken/jjwt-api@0.11.1?type=jar",
+        "pkg:maven/io.jsonwebtoken/jjwt-impl@0.11.1?type=jar",
+        "pkg:maven/io.jsonwebtoken/jjwt-jackson@0.11.1?type=jar",
+        "pkg:maven/jaxen/jaxen@1.2.0?type=jar",
+        "pkg:maven/org.jdom/jdom2@2.0.6?type=jar",
+        "pkg:maven/commons-io/commons-io@2.6?type=jar",
+        "pkg:maven/org.codehaus.groovy/groovy-all@2.4.15?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework.boot/spring-boot@2.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.2.2.RELEASE?type=jar",
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.yaml/snakeyaml@1.25?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework.boot/spring-boot@2.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework/spring-core@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-context@5.2.2.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework/spring-core@5.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework/spring-jcl@5.2.2.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework/spring-context@5.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework/spring-aop@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-beans@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-expression@5.2.2.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework/spring-aop@5.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework/spring-beans@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.2.2.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework/spring-beans@5.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework/spring-core@5.2.2.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework/spring-expression@5.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework/spring-core@5.2.2.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework.boot/spring-boot@2.2.2.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/ch.qos.logback/logback-classic@1.2.3?type=jar",
+        "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.12.1?type=jar",
+        "pkg:maven/org.slf4j/jul-to-slf4j@1.7.29?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.3?type=jar",
+      "dependsOn": [
+        "pkg:maven/ch.qos.logback/logback-core@1.2.3?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.29?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/ch.qos.logback/logback-core@1.2.3?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.slf4j/slf4j-api@1.7.29?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.12.1?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.slf4j/slf4j-api@1.7.29?type=jar",
+        "pkg:maven/org.apache.logging.log4j/log4j-api@2.12.1?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.12.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.29?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.slf4j/slf4j-api@1.7.29?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.springframework/spring-jcl@5.2.2.RELEASE?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.yaml/snakeyaml@1.25?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-data-jpa@2.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework.boot/spring-boot-starter-aop@2.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-jdbc@2.2.2.RELEASE?type=jar",
+        "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.1?type=jar",
+        "pkg:maven/jakarta.persistence/jakarta.persistence-api@2.2.3?type=jar",
+        "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3?type=jar",
+        "pkg:maven/org.hibernate/hibernate-core@5.4.9.Final?type=jar",
+        "pkg:maven/org.springframework.data/spring-data-jpa@2.2.3.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-aspects@5.2.2.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-aop@2.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-aop@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.aspectj/aspectjweaver@1.9.5?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.aspectj/aspectjweaver@1.9.5?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-jdbc@2.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.2.2.RELEASE?type=jar",
+        "pkg:maven/com.zaxxer/HikariCP@3.4.1?type=jar",
+        "pkg:maven/org.springframework/spring-jdbc@5.2.2.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/com.zaxxer/HikariCP@3.4.1?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.slf4j/slf4j-api@1.7.29?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework/spring-jdbc@5.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework/spring-beans@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-tx@5.2.2.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework/spring-tx@5.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework/spring-beans@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.2.2.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/jakarta.persistence/jakarta.persistence-api@2.2.3?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.hibernate/hibernate-core@5.4.9.Final?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar",
+        "pkg:maven/org.javassist/javassist@3.24.0-GA?type=jar",
+        "pkg:maven/net.bytebuddy/byte-buddy@1.10.4?type=jar",
+        "pkg:maven/antlr/antlr@2.7.7?type=jar",
+        "pkg:maven/org.jboss/jandex@2.1.1.Final?type=jar",
+        "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar",
+        "pkg:maven/org.dom4j/dom4j@2.1.1?type=jar",
+        "pkg:maven/org.hibernate.common/hibernate-commons-annotations@5.1.0.Final?type=jar",
+        "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.2?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.javassist/javassist@3.24.0-GA?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/net.bytebuddy/byte-buddy@1.10.4?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/antlr/antlr@2.7.7?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.jboss/jandex@2.1.1.Final?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.dom4j/dom4j@2.1.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.hibernate.common/hibernate-commons-annotations@5.1.0.Final?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.2?type=jar",
+      "dependsOn": [
+        "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.2?type=jar",
+        "pkg:maven/org.glassfish.jaxb/txw2@2.3.2?type=jar",
+        "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.8?type=jar",
+        "pkg:maven/org.jvnet.staxex/stax-ex@1.8.1?type=jar",
+        "pkg:maven/com.sun.xml.fastinfoset/FastInfoset@1.2.16?type=jar",
+        "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.1?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.2?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.glassfish.jaxb/txw2@2.3.2?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.8?type=jar",
+      "dependsOn": [
+        "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.1?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.jvnet.staxex/stax-ex@1.8.1?type=jar",
+      "dependsOn": [
+        "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.1?type=jar",
+        "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.2?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/com.sun.xml.fastinfoset/FastInfoset@1.2.16?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.springframework.data/spring-data-jpa@2.2.3.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework.data/spring-data-commons@2.2.3.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-orm@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-context@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-aop@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-tx@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-beans@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.29?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework.data/spring-data-commons@2.2.3.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework/spring-core@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-beans@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.29?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework/spring-orm@5.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework/spring-beans@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-jdbc@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-tx@5.2.2.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework/spring-aspects@5.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.aspectj/aspectjweaver@1.9.5?type=jar",
+        "pkg:maven/org.springframework/spring-orm@5.2.2.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.2.5.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-validation@2.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-web@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-webmvc@5.2.2.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-web@5.2.2.RELEASE?type=jar",
+        "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.10.1?type=jar",
+        "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.10.1?type=jar",
+        "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.10.1?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework/spring-web@5.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework/spring-beans@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.2.2.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.10.1?type=jar",
+      "dependsOn": [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.10.1?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.10.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.10.1?type=jar",
+      "dependsOn": [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.10.1?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.10.1?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.10.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.10.1?type=jar",
+      "dependsOn": [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.10.1?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.29?type=jar",
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.29?type=jar",
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.29?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.29?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.29?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.29?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.29?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-validation@2.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.2.2.RELEASE?type=jar",
+        "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.1?type=jar",
+        "pkg:maven/org.hibernate.validator/hibernate-validator@6.0.18.Final?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.hibernate.validator/hibernate-validator@6.0.18.Final?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar",
+        "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework/spring-webmvc@5.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework/spring-aop@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-beans@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-context@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-expression@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-web@5.2.2.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework.boot/spring-boot-devtools@2.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework.boot/spring-boot@2.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.2.2.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/javax.xml.bind/jaxb-api@2.4.0-b180830.0359?type=jar",
+      "dependsOn": [
+        "pkg:maven/javax.activation/javax.activation-api@1.2.0?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/javax.activation/javax.activation-api@1.2.0?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.springframework.boot/spring-boot-configuration-processor@2.2.2.RELEASE?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.10.3?type=jar",
+      "dependsOn": [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.10.1?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.10.1?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-security@2.2.2.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-aop@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework.security/spring-security-config@5.2.1.RELEASE?type=jar",
+        "pkg:maven/org.springframework.security/spring-security-web@5.2.1.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework.security/spring-security-config@5.2.1.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework.security/spring-security-core@5.2.1.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-aop@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-beans@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-context@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.2.2.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework.security/spring-security-core@5.2.1.RELEASE?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.springframework.security/spring-security-web@5.2.1.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework.security/spring-security-core@5.2.1.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-aop@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-beans@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-context@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-expression@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-web@5.2.2.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.postgresql/postgresql@42.2.8?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.springfox/springfox-swagger2@2.9.2?type=jar",
+      "dependsOn": [
+        "pkg:maven/io.swagger/swagger-annotations@1.5.20?type=jar",
+        "pkg:maven/io.swagger/swagger-models@1.5.20?type=jar",
+        "pkg:maven/io.springfox/springfox-spi@2.9.2?type=jar",
+        "pkg:maven/io.springfox/springfox-schema@2.9.2?type=jar",
+        "pkg:maven/io.springfox/springfox-swagger-common@2.9.2?type=jar",
+        "pkg:maven/io.springfox/springfox-spring-web@2.9.2?type=jar",
+        "pkg:maven/com.google.guava/guava@20.0?type=jar",
+        "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.29?type=jar",
+        "pkg:maven/org.springframework.plugin/spring-plugin-core@1.2.0.RELEASE?type=jar",
+        "pkg:maven/org.springframework.plugin/spring-plugin-metadata@1.2.0.RELEASE?type=jar",
+        "pkg:maven/org.mapstruct/mapstruct@1.2.0.Final?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.swagger/swagger-annotations@1.5.20?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.swagger/swagger-models@1.5.20?type=jar",
+      "dependsOn": [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.10.1?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.29?type=jar",
+        "pkg:maven/io.swagger/swagger-annotations@1.5.20?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.springfox/springfox-spi@2.9.2?type=jar",
+      "dependsOn": [
+        "pkg:maven/io.springfox/springfox-core@2.9.2?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.springfox/springfox-core@2.9.2?type=jar",
+      "dependsOn": [
+        "pkg:maven/net.bytebuddy/byte-buddy@1.10.4?type=jar",
+        "pkg:maven/com.google.guava/guava@20.0?type=jar",
+        "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.29?type=jar",
+        "pkg:maven/org.springframework.plugin/spring-plugin-core@1.2.0.RELEASE?type=jar",
+        "pkg:maven/org.springframework.plugin/spring-plugin-metadata@1.2.0.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/com.google.guava/guava@20.0?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.springframework.plugin/spring-plugin-core@1.2.0.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework/spring-beans@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-context@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-aop@5.2.2.RELEASE?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.29?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework.plugin/spring-plugin-metadata@1.2.0.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework.plugin/spring-plugin-core@1.2.0.RELEASE?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.29?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.springfox/springfox-schema@2.9.2?type=jar",
+      "dependsOn": [
+        "pkg:maven/io.springfox/springfox-core@2.9.2?type=jar",
+        "pkg:maven/io.springfox/springfox-spi@2.9.2?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.springfox/springfox-swagger-common@2.9.2?type=jar",
+      "dependsOn": [
+        "pkg:maven/io.swagger/swagger-annotations@1.5.20?type=jar",
+        "pkg:maven/io.swagger/swagger-models@1.5.20?type=jar",
+        "pkg:maven/io.springfox/springfox-spi@2.9.2?type=jar",
+        "pkg:maven/io.springfox/springfox-schema@2.9.2?type=jar",
+        "pkg:maven/io.springfox/springfox-spring-web@2.9.2?type=jar",
+        "pkg:maven/com.google.guava/guava@20.0?type=jar",
+        "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.29?type=jar",
+        "pkg:maven/org.springframework.plugin/spring-plugin-core@1.2.0.RELEASE?type=jar",
+        "pkg:maven/org.springframework.plugin/spring-plugin-metadata@1.2.0.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.springfox/springfox-spring-web@2.9.2?type=jar",
+      "dependsOn": [
+        "pkg:maven/com.google.guava/guava@20.0?type=jar",
+        "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.29?type=jar",
+        "pkg:maven/org.springframework.plugin/spring-plugin-core@1.2.0.RELEASE?type=jar",
+        "pkg:maven/org.springframework.plugin/spring-plugin-metadata@1.2.0.RELEASE?type=jar",
+        "pkg:maven/io.springfox/springfox-spi@2.9.2?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.mapstruct/mapstruct@1.2.0.Final?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.springfox/springfox-swagger-ui@2.9.2?type=jar",
+      "dependsOn": [
+        "pkg:maven/io.springfox/springfox-spring-web@2.9.2?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.fenixedu/feaf4j-api@2.3.1?type=jar",
+      "dependsOn": [
+        "pkg:maven/com.google.code.gson/gson@2.8.6?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.29?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/com.google.code.gson/gson@2.8.6?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.fenixedu/feaf4j-okhttp@2.3.1?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.fenixedu/feaf4j-api@2.3.1?type=jar",
+        "pkg:maven/com.squareup.okhttp/okhttp@2.2.0?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.29?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/com.squareup.okhttp/okhttp@2.2.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/com.squareup.okio/okio@1.2.0?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/com.squareup.okio/okio@1.2.0?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.springframework.retry/spring-retry@1.2.5.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.springframework/spring-core@5.2.2.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.jsonwebtoken/jjwt-api@0.11.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.jsonwebtoken/jjwt-impl@0.11.1?type=jar",
+      "dependsOn": [
+        "pkg:maven/io.jsonwebtoken/jjwt-api@0.11.1?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.jsonwebtoken/jjwt-jackson@0.11.1?type=jar",
+      "dependsOn": [
+        "pkg:maven/io.jsonwebtoken/jjwt-api@0.11.1?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/jaxen/jaxen@1.2.0?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.jdom/jdom2@2.0.6?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/commons-io/commons-io@2.6?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.codehaus.groovy/groovy-all@2.4.15?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.pac4j/pac4j-cas@3.0.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.pac4j/pac4j-core@3.0.0?type=jar",
+        "pkg:maven/org.jasig.cas.client/cas-client-core@3.4.1?type=jar",
+        "pkg:maven/org.jasig.cas.client/cas-client-support-saml@3.4.1?type=jar",
+        "pkg:maven/javax.servlet/javax.servlet-api@3.1.0?type=jar",
+        "pkg:maven/com.google.guava/guava@21.0?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.pac4j/pac4j-core@3.0.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar",
+        "pkg:maven/javax.servlet/javax.servlet-api@3.1.0?type=jar",
+        "pkg:maven/com.google.guava/guava@21.0?type=jar",
+        "pkg:maven/org.springframework.security/spring-security-crypto@4.2.2.RELEASE?type=jar",
+        "pkg:maven/org.apache.shiro/shiro-core@1.3.2?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.jasig.cas.client/cas-client-core@3.4.1?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.jasig.cas.client/cas-client-support-saml@3.4.1?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.jasig.cas.client/cas-client-core@3.4.1?type=jar",
+        "pkg:maven/joda-time/joda-time@2.7?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/joda-time/joda-time@2.7?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/javax.servlet/javax.servlet-api@3.1.0?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.google.guava/guava@21.0?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.pac4j/pac4j-config@3.0.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.pac4j/pac4j-core@3.0.0?type=jar",
+        "pkg:maven/org.pac4j/pac4j-cas@3.0.0?type=jar",
+        "pkg:maven/org.pac4j/pac4j-saml@3.0.0?type=jar",
+        "pkg:maven/org.pac4j/pac4j-oauth@3.0.0?type=jar",
+        "pkg:maven/org.pac4j/pac4j-oidc@3.0.0?type=jar",
+        "pkg:maven/org.pac4j/pac4j-ldap@3.0.0?type=jar",
+        "pkg:maven/org.pac4j/pac4j-http@3.0.0?type=jar",
+        "pkg:maven/com.zaxxer/HikariCP@2.6.1?type=jar",
+        "pkg:maven/org.pac4j/pac4j-sql@3.0.0?type=jar",
+        "pkg:maven/org.springframework.security/spring-security-crypto@4.2.2.RELEASE?type=jar",
+        "pkg:maven/org.apache.shiro/shiro-core@1.3.2?type=jar",
+        "pkg:maven/junit/junit@4.12?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.pac4j/pac4j-saml@3.0.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.pac4j/pac4j-core@3.0.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-core@3.3.0?type=jar",
+        "pkg:maven/net.shibboleth.utilities/java-support@7.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-saml-api@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-saml-impl@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-soap-api@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-xmlsec-api@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-security-api@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-security-impl@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-profile-api@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-profile-impl@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-messaging-api@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-messaging-impl@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-xmlsec-impl@3.3.0?type=jar",
+        "pkg:maven/com.google.guava/guava@21.0?type=jar",
+        "pkg:maven/org.cryptacular/cryptacular@1.1.0?type=jar",
+        "pkg:maven/joda-time/joda-time@2.9.2?type=jar",
+        "pkg:maven/xalan/xalan@2.7.2?type=jar",
+        "pkg:maven/org.apache.velocity/velocity@1.7?type=jar",
+        "pkg:maven/commons-collections/commons-collections@3.2.2?type=jar",
+        "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.25?type=jar",
+        "pkg:maven/org.springframework/spring-core@4.3.7.RELEASE?type=jar",
+        "pkg:maven/javax.servlet/javax.servlet-api@3.1.0?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.opensaml/opensaml-core@3.3.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/io.dropwizard.metrics/metrics-core@3.1.2?type=jar",
+        "pkg:maven/net.shibboleth.utilities/java-support@7.3.0?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.10?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.dropwizard.metrics/metrics-core@3.1.2?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/net.shibboleth.utilities/java-support@7.3.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/commons-codec/commons-codec@1.10?type=jar",
+        "pkg:maven/com.google.code.findbugs/jsr305@3.0.1?type=jar",
+        "pkg:maven/com.google.guava/guava@21.0?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/commons-codec/commons-codec@1.10?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.opensaml/opensaml-saml-api@3.3.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.opensaml/opensaml-xmlsec-api@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-soap-api@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-messaging-api@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-profile-api@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-storage-api@3.3.0?type=jar",
+        "pkg:maven/net.shibboleth.utilities/java-support@7.3.0?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.10?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.opensaml/opensaml-xmlsec-api@3.3.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.opensaml/opensaml-security-api@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-messaging-api@3.3.0?type=jar",
+        "pkg:maven/net.shibboleth.utilities/java-support@7.3.0?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.10?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.opensaml/opensaml-soap-api@3.3.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.opensaml/opensaml-xmlsec-api@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-messaging-api@3.3.0?type=jar",
+        "pkg:maven/org.apache.httpcomponents/httpclient@4.3.6?type=jar",
+        "pkg:maven/net.shibboleth.utilities/java-support@7.3.0?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.10?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.opensaml/opensaml-messaging-api@3.3.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.opensaml/opensaml-core@3.3.0?type=jar",
+        "pkg:maven/org.apache.httpcomponents/httpclient@4.3.6?type=jar",
+        "pkg:maven/net.shibboleth.utilities/java-support@7.3.0?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.10?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.opensaml/opensaml-profile-api@3.3.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.opensaml/opensaml-core@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-messaging-api@3.3.0?type=jar",
+        "pkg:maven/net.shibboleth.utilities/java-support@7.3.0?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.10?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.opensaml/opensaml-storage-api@3.3.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/net.shibboleth.utilities/java-support@7.3.0?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.10?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.opensaml/opensaml-saml-impl@3.3.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.opensaml/opensaml-profile-api@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-saml-api@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-storage-api@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-security-impl@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-xmlsec-impl@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-soap-impl@3.3.0?type=jar",
+        "pkg:maven/org.apache.velocity/velocity@1.7?type=jar",
+        "pkg:maven/org.apache.httpcomponents/httpclient@4.3.6?type=jar",
+        "pkg:maven/net.shibboleth.utilities/java-support@7.3.0?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.10?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.opensaml/opensaml-security-impl@3.3.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.opensaml/opensaml-security-api@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-messaging-api@3.3.0?type=jar",
+        "pkg:maven/net.shibboleth.utilities/java-support@7.3.0?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.10?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.opensaml/opensaml-xmlsec-impl@3.3.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.opensaml/opensaml-xmlsec-api@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-security-impl@3.3.0?type=jar",
+        "pkg:maven/net.shibboleth.utilities/java-support@7.3.0?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.10?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.opensaml/opensaml-soap-impl@3.3.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.opensaml/opensaml-soap-api@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-profile-api@3.3.0?type=jar",
+        "pkg:maven/net.shibboleth.utilities/java-support@7.3.0?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.10?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.apache.velocity/velocity@1.7?type=jar",
+      "dependsOn": [
+        "pkg:maven/commons-lang/commons-lang@2.4?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.apache.httpcomponents/httpclient@4.3.6?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.apache.httpcomponents/httpcore@4.3.3?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.10?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.apache.httpcomponents/httpcore@4.3.3?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.opensaml/opensaml-security-api@3.3.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.opensaml/opensaml-core@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-messaging-api@3.3.0?type=jar",
+        "pkg:maven/org.apache.santuario/xmlsec@2.0.5?type=jar",
+        "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.54?type=jar",
+        "pkg:maven/net.shibboleth.utilities/java-support@7.3.0?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.10?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.apache.santuario/xmlsec@2.0.5?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar",
+        "pkg:maven/org.codehaus.woodstox/woodstox-core-asl@4.4.1?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.10?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.codehaus.woodstox/woodstox-core-asl@4.4.1?type=jar",
+      "dependsOn": [
+        "pkg:maven/javax.xml.stream/stax-api@1.0-2?type=jar",
+        "pkg:maven/org.codehaus.woodstox/stax2-api@3.1.4?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/javax.xml.stream/stax-api@1.0-2?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.codehaus.woodstox/stax2-api@3.1.4?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.54?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.opensaml/opensaml-profile-impl@3.3.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.opensaml/opensaml-profile-api@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-messaging-api@3.3.0?type=jar",
+        "pkg:maven/org.opensaml/opensaml-xmlsec-api@3.3.0?type=jar",
+        "pkg:maven/net.shibboleth.utilities/java-support@7.3.0?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.10?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.opensaml/opensaml-messaging-impl@3.3.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.opensaml/opensaml-messaging-api@3.3.0?type=jar",
+        "pkg:maven/net.shibboleth.utilities/java-support@7.3.0?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.10?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.cryptacular/cryptacular@1.1.0?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/joda-time/joda-time@2.9.2?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/xalan/xalan@2.7.2?type=jar",
+      "dependsOn": [
+        "pkg:maven/xalan/serializer@2.7.2?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/xalan/serializer@2.7.2?type=jar",
+      "dependsOn": [
+        "pkg:maven/xml-apis/xml-apis@1.3.04?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/xml-apis/xml-apis@1.3.04?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/commons-lang/commons-lang@2.4?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/commons-collections/commons-collections@3.2.2?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.25?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.springframework/spring-core@4.3.7.RELEASE?type=jar",
+      "dependsOn": [
+        "pkg:maven/commons-logging/commons-logging@1.2?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/commons-logging/commons-logging@1.2?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.pac4j/pac4j-oauth@3.0.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.pac4j/pac4j-core@3.0.0?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.10?type=jar",
+        "pkg:maven/com.github.scribejava/scribejava-apis@3.3.0?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.7?type=jar",
+        "pkg:maven/javax.servlet/javax.servlet-api@3.1.0?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/com.github.scribejava/scribejava-apis@3.3.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/com.github.scribejava/scribejava-core@3.3.0?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/com.github.scribejava/scribejava-core@3.3.0?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.7?type=jar",
+      "dependsOn": [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.8.0?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.8.7?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.8.0?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.8.7?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.pac4j/pac4j-oidc@3.0.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.pac4j/pac4j-core@3.0.0?type=jar",
+        "pkg:maven/com.nimbusds/oauth2-oidc-sdk@5.24.2?type=jar",
+        "pkg:maven/com.nimbusds/nimbus-jose-jwt@4.35?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/com.nimbusds/oauth2-oidc-sdk@5.24.2?type=jar",
+      "dependsOn": [
+        "pkg:maven/javax.mail/mail@1.4.7?type=jar",
+        "pkg:maven/com.github.stephenc.jcip/jcip-annotations@1.0-1?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.5?type=jar",
+        "pkg:maven/org.apache.commons/commons-collections4@4.1?type=jar",
+        "pkg:maven/net.minidev/json-smart@1.3.1?type=jar",
+        "pkg:maven/com.nimbusds/lang-tag@1.7?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/javax.mail/mail@1.4.7?type=jar",
+      "dependsOn": [
+        "pkg:maven/javax.activation/activation@1.1?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/javax.activation/activation@1.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.github.stephenc.jcip/jcip-annotations@1.0-1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.commons/commons-lang3@3.5?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.commons/commons-collections4@4.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/net.minidev/json-smart@1.3.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.nimbusds/lang-tag@1.7?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.nimbusds/nimbus-jose-jwt@4.35?type=jar",
+      "dependsOn": [
+        "pkg:maven/com.github.stephenc.jcip/jcip-annotations@1.0-1?type=jar",
+        "pkg:maven/net.minidev/json-smart@1.3.1?type=jar",
+        "pkg:maven/org.bouncycastle/bcpkix-jdk15on@1.55?type=jar",
+        "pkg:maven/net.minidev/json-smart@2.3?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.bouncycastle/bcpkix-jdk15on@1.55?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.55?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.55?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.pac4j/pac4j-ldap@3.0.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.pac4j/pac4j-core@3.0.0?type=jar",
+        "pkg:maven/org.ldaptive/ldaptive@1.2.1?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.ldaptive/ldaptive@1.2.1?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar",
+        "pkg:maven/commons-cli/commons-cli@1.3.1?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/commons-cli/commons-cli@1.3.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.pac4j/pac4j-http@3.0.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.pac4j/pac4j-core@3.0.0?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.7?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.10?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/com.zaxxer/HikariCP@2.6.1?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.pac4j/pac4j-sql@3.0.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.pac4j/pac4j-core@3.0.0?type=jar",
+        "pkg:maven/org.jdbi/jdbi@2.78?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.jdbi/jdbi@2.78?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.springframework.security/spring-security-crypto@4.2.2.RELEASE?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.shiro/shiro-core@1.3.2?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar",
+        "pkg:maven/commons-beanutils/commons-beanutils@1.8.3?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/commons-beanutils/commons-beanutils@1.8.3?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/junit/junit@4.12?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.hamcrest/hamcrest-core@1.3?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.hamcrest/hamcrest-core@1.3?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.pac4j/pac4j-couch@3.0.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.pac4j/pac4j-core@3.0.0?type=jar",
+        "pkg:maven/org.ektorp/org.ektorp@1.4.4?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.3.3?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.ektorp/org.ektorp@1.4.4?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.apache.httpcomponents/httpclient@4.3?type=jar",
+        "pkg:maven/org.apache.httpcomponents/httpclient-cache@4.3?type=jar",
+        "pkg:maven/commons-io/commons-io@2.0.1?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar",
+        "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.25?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.3.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.3.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.7?type=jar",
+        "pkg:maven/net.sourceforge.findbugs/annotations@1.3.2?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.apache.httpcomponents/httpclient@4.3?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.apache.httpcomponents/httpcore@4.3?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.10?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.apache.httpcomponents/httpcore@4.3?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.httpcomponents/httpclient-cache@4.3?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.apache.httpcomponents/httpclient@4.3?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/commons-io/commons-io@2.0.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.3.3?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.3.3?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/net.sourceforge.findbugs/annotations@1.3.2?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.3.3?type=jar",
+      "dependsOn": [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.3.3?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.pac4j/pac4j-gae@3.0.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.pac4j/pac4j-core@3.0.0?type=jar",
+        "pkg:maven/com.google.appengine/appengine-api-1.0-sdk@1.9.50?type=jar",
+        "pkg:maven/com.google.appengine/appengine-jsr107cache@1.9.50?type=jar",
+        "pkg:maven/net.sf.jsr107cache/jsr107cache@1.1?type=jar",
+        "pkg:maven/javax.servlet/javax.servlet-api@3.1.0?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/com.google.appengine/appengine-api-1.0-sdk@1.9.50?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.google.appengine/appengine-jsr107cache@1.9.50?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/net.sf.jsr107cache/jsr107cache@1.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.pac4j/pac4j-jwt@3.0.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.pac4j/pac4j-core@3.0.0?type=jar",
+        "pkg:maven/com.nimbusds/nimbus-jose-jwt@4.35?type=jar",
+        "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.56?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/net.minidev/json-smart@2.3?type=jar",
+      "dependsOn": [
+        "pkg:maven/net.minidev/accessors-smart@1.2?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/net.minidev/accessors-smart@1.2?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.ow2.asm/asm@5.0.4?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.ow2.asm/asm@5.0.4?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.56?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.pac4j/pac4j-kerberos@3.0.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.pac4j/pac4j-core@3.0.0?type=jar",
+        "pkg:maven/org.springframework/spring-core@4.3.7.RELEASE?type=jar",
+        "pkg:maven/javax.servlet/javax.servlet-api@3.1.0?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.pac4j/pac4j-mongo@3.0.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.pac4j/pac4j-core@3.0.0?type=jar",
+        "pkg:maven/org.mongodb/mongo-java-driver@3.4.2?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.mongodb/mongo-java-driver@3.4.2?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.pac4j/pac4j-openid@3.0.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.pac4j/pac4j-core@3.0.0?type=jar",
+        "pkg:maven/org.openid4java/openid4java@1.0.0?type=jar",
+        "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.25?type=jar",
+        "pkg:maven/xml-apis/xml-apis@1.0.b2?type=jar",
+        "pkg:maven/javax.servlet/javax.servlet-api@3.1.0?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.openid4java/openid4java@1.0.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.apache.httpcomponents/httpclient@4.1?type=jar",
+        "pkg:maven/net.sourceforge.nekohtml/nekohtml@1.9.10?type=jar",
+        "pkg:maven/com.google.inject/guice@2.0?type=jar",
+        "pkg:maven/xerces/xercesImpl@2.8.1?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.apache.httpcomponents/httpclient@4.1?type=jar",
+      "dependsOn": [
+        "pkg:maven/org.apache.httpcomponents/httpcore@4.1?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.10?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.apache.httpcomponents/httpcore@4.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/net.sourceforge.nekohtml/nekohtml@1.9.10?type=jar",
+      "dependsOn": [
+        "pkg:maven/xerces/xercesImpl@2.8.1?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/xerces/xercesImpl@2.8.1?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.google.inject/guice@2.0?type=jar",
+      "dependsOn": [
+        "pkg:maven/aopalliance/aopalliance@1.0?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/aopalliance/aopalliance@1.0?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/xml-apis/xml-apis@1.0.b2?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.pac4j/pac4j@3.0.0?type=pom",
+      "dependsOn": [
+        "pkg:maven/org.pac4j/pac4j-core@3.0.0?type=jar",
+        "pkg:maven/org.pac4j/pac4j-cas@3.0.0?type=jar",
+        "pkg:maven/org.pac4j/pac4j-saml@3.0.0?type=jar",
+        "pkg:maven/org.pac4j/pac4j-oauth@3.0.0?type=jar",
+        "pkg:maven/org.pac4j/pac4j-oidc@3.0.0?type=jar",
+        "pkg:maven/org.pac4j/pac4j-ldap@3.0.0?type=jar",
+        "pkg:maven/org.pac4j/pac4j-http@3.0.0?type=jar",
+        "pkg:maven/org.pac4j/pac4j-sql@3.0.0?type=jar",
+        "pkg:maven/org.pac4j/pac4j-config@3.0.0?type=jar",
+        "pkg:maven/org.pac4j/pac4j-openid@3.0.0?type=jar",
+        "pkg:maven/org.pac4j/pac4j-gae@3.0.0?type=jar",
+        "pkg:maven/org.pac4j/pac4j-jwt@3.0.0?type=jar",
+        "pkg:maven/org.pac4j/pac4j-mongo@3.0.0?type=jar",
+        "pkg:maven/org.pac4j/pac4j-couch@3.0.0?type=jar",
+        "pkg:maven/org.pac4j/pac4j-kerberos@3.0.0?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.foo.bar/always@1.0.0-SNAPSHOT?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.foo.bar/profile-only@1.0.0-SNAPSHOT?type=jar",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.foo.bar/foobar@1.0.0-SNAPSHOT?type=pom",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.infradna.tool/bridge-method-annotation@1.13?type=jar",
+      "dependsOn": []
+    }
+  ]
+}


### PR DESCRIPTION
`depscan` is scanning all modules in spoon project. It has also included `spoon-corev10.4.0` in components and that's why spoon is able to run.

> By the way, it also included `spoon-javadoc` module which is not published on maven.